### PR TITLE
Configure Nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,22 +3,45 @@ Ansible playbook for shared infrastructure
 
 ## Prerequisites
 
-- A Red Hat Enterprise Linux 9.x host - request one from OIT [here](https://gatech.service-now.com/technology?id=sc_cat_item&sys_id=4d656885dba3c850fc9efe8d0f96194f&sysparm_category=eb2e1a60db11c0987bbc68461b96191f)
+- A Red Hat Enterprise Linux 9 host - request one from OIT [here](https://gatech.service-now.com/technology?id=sc_cat_item&sys_id=4d656885dba3c850fc9efe8d0f96194f&sysparm_category=eb2e1a60db11c0987bbc68461b96191f)
 - Ansible - see install guide [here](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html)
+
+You do **not** need Nomad or Consul installed locally, but they may be helpful.
+
+### Notes on certificate issuance
+
+This playbook will attempt to issue an ACME certificate for the fully-qualified domain name specified in the inventory using the [http-01 challenge](https://letsencrypt.org/docs/challenge-types/). This means that the domain name must be **resolvable in public DNS** and the host must have **port 80 open to the Internet**. If the challenge fails, a self-signed certificate will be used.
+
+For OIT-managed hosts, DNS setup should be completed before system is handed off. Firewall changes must be submitted to the CSR responsible for the VLAN.
+
+The playbook will check if the http-01 challenge passes from the controller's perspective (i.e. your machine), but if you are running this against an OIT-managed system, that is not necessarily representative of what Let's Encrypt or another ACME issuer would see.
+
+The certificate will also have SANs for `*.{datacenter}.robojackets.net` and `*.robojackets.org`, using dns-01 challenges. You will be prompted for Hurricane Electric credentials when necessary.
 
 Set up an inventory file like so:
 
 ```yaml
 ---
-platform:
+ungrouped:
   hosts:
     bcdc1:
+      # ansible_host is assumed to be an IP address in several places
       ansible_host: 1.2.3.4
       ansible_user: gburdell3
       ansible_become: true
       datacenter: bcdc
       node_name: bcdc1
       region: campus
+      owner_contact_name: George Burdell
+      owner_contact_email: gburdell3@gatech.edu
+      acme_server: letsencrypt_test
+      fully_qualified_domain_name: bcdc1.gatech.edu
+      dns_resolvers:
+      # these are the OIT-managed recursive resolvers, aka brahmas
+      # this list is join()'ed and passed to the resolver directive in nginx; you can add additional config if you'd like
+      - 130.207.244.251
+      - 130.207.244.244
+      - 128.61.244.254
 ```
 
 Run the playbook like so:

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,3 @@
 [defaults]
-inventory=inventory.yml
+inventory = inventory.yml
+nocows = 1

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,7 +1,17 @@
 ---
 - name: Bootstrap web app platform
-  hosts: platform
+  hosts: all
   roles:
   - docker
   - consul
   - nomad
+  - dhparam
+  - self-signed-certificate
+  - acme-account
+  - clean-stuck-jobs
+  - docker-system-prune
+  - firewall-rules
+  - vouch
+  - nginx
+  - acme-issuance
+  - nginx

--- a/roles/acme-account/tasks/main.yml
+++ b/roles/acme-account/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 #
 # Create an account with Let's Encrypt (or another ACME service)
+# https://github.com/acmesh-official/acme.sh
 #
 - name: Check if an ACME account already exists for {{ acme_server }}
   ansible.builtin.uri:

--- a/roles/acme-account/tasks/main.yml
+++ b/roles/acme-account/tasks/main.yml
@@ -1,0 +1,75 @@
+---
+#
+# Create an account with Let's Encrypt (or another ACME service)
+#
+- name: Check if an ACME account already exists for {{ acme_server }}
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    unix_socket: /var/run/docker.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    method: GET
+    return_content: true
+    url: http://localhost/v1.43/volumes/acme-account-{{ acme_server }}
+    status_code:
+    - 200
+    - 404
+  register: acme_volume
+
+- name: Register an ACME account with {{ acme_server }}
+  ansible.builtin.command:
+    argv:
+    - docker
+    - run
+    - --pull
+    - always
+    - --rm
+    - --network
+    - host
+    - --read-only
+    - --rm
+    - --mount
+    - type=volume,source=acme-account-{{ acme_server }},destination=/acme.sh/
+    - neilpang/acme.sh
+    - --register-account
+    - --server
+    - "{{ acme_server }}"
+    - --accountkeylength
+    - 4096
+    - --email
+    - "{{ owner_contact_email }}"
+  register: acme_output
+  when: acme_volume.status == 404
+
+- name: Store ACME account thumbprint in Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    body: >-
+      {{ acme_output.stdout | regex_search("ACCOUNT_THUMBPRINT='(.+)'", '\1') | first }}
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: PUT
+    url: http://localhost/v1/kv/acme/{{ acme_server }}-thumbprint
+  when: acme_volume.status == 404
+
+- name: Verify ACME account thumbprint is in Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/kv/acme/{{ acme_server }}-thumbprint

--- a/roles/acme-issuance/tasks/main.yml
+++ b/roles/acme-issuance/tasks/main.yml
@@ -1,0 +1,145 @@
+---
+#
+# Issue a certificate from Let's Encrypt (or another ACME service)
+#
+- name: Check to see if http-01 challenge passes from controller's perspective
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    method: GET
+    return_content: true
+    url: http://{{ fully_qualified_domain_name }}/.well-known/acme-challenge/ansible-test
+    status_code:
+    - 200
+    timeout: 5
+  delegate_to: 127.0.0.1
+  ignore_errors: true
+  register: acme_challenge_test
+
+- name: Check if a volume is already created for {{ acme_server }}
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    unix_socket: /var/run/docker.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    method: GET
+    return_content: true
+    url: http://localhost/v1.43/volumes/acme-certificate-{{ acme_server }}
+    status_code:
+    - 200
+    - 404
+  register: acme_certificate_volume
+  when: not (acme_challenge_test is failed)
+
+- name: Check if a certificate was already issued from {{ acme_server }}
+  ansible.builtin.stat:
+    path: "{{ acme_certificate_volume.json.Mountpoint }}/fullchain.pem"
+  when: acme_certificate_volume.status == 200 and not (acme_challenge_test is failed)
+  register: server_cert
+
+- name: Request certificate issuance
+  when: not (acme_challenge_test is failed) and (acme_certificate_volume.status == 404 or not server_cert.stat.exists)
+  block:
+
+  - name: Retrieve ACME account thumbprint from Consul
+    ansible.builtin.uri:
+      follow_redirects: none
+      force: true
+      return_content: true
+      unix_socket: /var/opt/nomad/run/consul.sock
+      use_netrc: false
+      use_proxy: false
+      validate_certs: false
+      headers:
+        X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+      method: GET
+      url: http://localhost/v1/kv/acme/{{ acme_server }}-thumbprint
+    register: acme_account_thumbprint_consul
+
+  - name: Fail if nginx did not return the expected challenge response
+    ansible.builtin.fail:
+      msg: Nginx did not return the expected response for the ACME http-01 challenge. Issuance would not be successful.
+    when: acme_challenge_test.status != 200 or acme_challenge_test.content != "ansible-test."+(acme_account_thumbprint_consul.json.0.Value | b64decode)
+
+  - name: Prompt for Hurricane Electric username
+    ansible.builtin.pause:
+      prompt: Please enter the username to use with Hurricane Electric to complete ACME dns-01 challenges
+    register: hurricane_electric_username
+
+  - name: Prompt for Hurricane Electric password
+    ansible.builtin.pause:
+      prompt: Please enter the password to use with Hurricane Electric to complete ACME dns-01 challenges
+    register: hurricane_electric_password
+
+  - name: Verify Hurricane Electric credentials
+    ansible.builtin.uri:
+      follow_redirects: none
+      force: true
+      return_content: true
+      use_netrc: false
+      use_proxy: false
+      validate_certs: true
+      body:
+        email: "{{ hurricane_electric_username.user_input }}"
+        pass: "{{ hurricane_electric_password.user_input }}"
+        submit: Login!
+      body_format: form-urlencoded
+      method: POST
+      url: https://dns.he.net
+    delegate_to: 127.0.0.1
+    register: hurricane_electric_login
+    failed_when: >-
+      "Zone Management" not in hurricane_electric_login.content
+
+  - name: Issue a certificate from {{ acme_server }} - this will take a few minutes, be patient, drink some water
+    ansible.builtin.command:
+      argv:
+      - docker
+      - run
+      - --pull
+      - always
+      - --rm
+      - --network
+      - host
+      - --read-only
+      - --rm
+      - --mount
+      - type=volume,source=acme-account-{{ acme_server }},destination=/acme.sh/
+      - --mount
+      - type=volume,source=acme-certificate-{{ acme_server }},destination=/certificate/
+      - --env
+      - HE_Username={{ hurricane_electric_username.user_input }}
+      - --env
+      - HE_Password={{ hurricane_electric_password.user_input }}
+      - neilpang/acme.sh
+      - --issue
+      - --server
+      - "{{ acme_server }}"
+      - --domain
+      - "{{ fully_qualified_domain_name }}"
+      - --stateless
+      - --domain
+      - "*.{{ datacenter }}.robojackets.net"
+      - --dns
+      - dns_he
+      - --domain
+      - "*.robojackets.org"
+      - --dns
+      - dns_he
+      - --keylength
+      - ec-384
+      - --cert-file
+      - /certificate/cert.pem
+      - --key-file
+      - /certificate/key.pem
+      - --ca-file
+      - /certificate/ca.pem
+      - --fullchain-file
+      - /certificate/fullchain.pem
+      - --ocsp-must-staple
+      - --ecc

--- a/roles/acme-issuance/tasks/main.yml
+++ b/roles/acme-issuance/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 #
 # Issue a certificate from Let's Encrypt (or another ACME service)
+# https://github.com/acmesh-official/acme.sh
 #
 - name: Check to see if http-01 challenge passes from controller's perspective
   ansible.builtin.uri:

--- a/roles/clean-stuck-jobs/tasks/clean-stuck-job.yml
+++ b/roles/clean-stuck-jobs/tasks/clean-stuck-job.yml
@@ -1,0 +1,38 @@
+---
+#
+# Clean up a single stuck job, for use in a loop
+#
+- name: Check {{ item.Name }} health in Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/health/checks/{{ item.Name }}
+  register: service_status
+
+- name: Stop and purge {{ item.Name }} job
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: DELETE
+    url: http://127.0.0.1:4646/v1/job/{{ item.Name }}?purge=true
+  when: (service_status.json | length) == 0 or service_status.json[0].Status != "passing"
+
+- name: Request garbage collection at end of loop
+  ansible.builtin.set_fact:
+    needs_nomad_garbage_collection: true
+    cacheable: yes
+  when: (service_status.json | length) == 0 or service_status.json[0].Status != "passing"

--- a/roles/clean-stuck-jobs/tasks/main.yml
+++ b/roles/clean-stuck-jobs/tasks/main.yml
@@ -1,0 +1,92 @@
+---
+#
+# Clean up "stuck" jobs in Nomad
+# Later roles and/or other mechanisms are responsible for restoring any jobs that are removed by this role
+#
+- name: Retrieve currently registered service jobs within Nomad
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: GET
+    url: http://127.0.0.1:4646/v1/jobs?filter=Type%3D%3Dservice
+  register: nomad_service_jobs
+
+- name: Get node information
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: GET
+    url: http://127.0.0.1:4646/v1/nodes
+  register: nomad_nodes_list
+
+- name: Mark node ineligible for scheduling
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: POST
+    body:
+      Eligibility: ineligible
+    body_format: json
+    url: http://127.0.0.1:4646/v1/node/{{ nomad_nodes_list.json[0].ID }}/eligibility
+  register: mark_node_ineligible
+  when: (nomad_service_jobs.json | length) > 0 and nomad_nodes_list.json[0].SchedulingEligibility == "eligible"
+  changed_when: true
+
+- name: Loop over jobs
+  include_tasks: clean-stuck-job.yml
+  loop: "{{ nomad_service_jobs.json }}"
+
+- name: Run garbage collection
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: PUT
+    url: http://127.0.0.1:4646/v1/system/gc
+  when: "'needs_nomad_garbage_collection' in ansible_facts"
+
+- name: Wait 10 seconds for garbage collection to complete
+  ansible.builtin.pause:
+    seconds: 10
+  when: "'needs_nomad_garbage_collection' in ansible_facts"
+
+- name: Mark node eligible for scheduling
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: POST
+    body:
+      Eligibility: eligible
+    body_format: json
+    url: http://127.0.0.1:4646/v1/node/{{ nomad_nodes_list.json[0].ID }}/eligibility
+  when: (nomad_nodes_list.json[0].SchedulingEligibility == "ineligible") or (mark_node_ineligible.status is defined)
+  changed_when: true

--- a/roles/consul/tasks/main.yml
+++ b/roles/consul/tasks/main.yml
@@ -41,7 +41,7 @@
     dest: /etc/consul.d/consul.hcl
     owner: consul
     group: consul
-    mode: '0600'
+    mode: '0400'
     validate: consul validate -config-format=hcl %s
   register: consul_hcl_template
 
@@ -51,43 +51,47 @@
     state: directory
     mode: '0777'
 
-- name: Start Consul service
-  ansible.builtin.systemd_service:
-    name: consul
-    state: started
-    enabled: false
+- name: Bootstrap Consul
   when: "'consul_token' not in ansible_facts or ansible_facts['consul_token'] == None"
+  block:
 
-- name: Wait for Consul socket to be available
-  ansible.builtin.wait_for:
-    path: /var/opt/nomad/run/consul.sock
-    state: present
-    timeout: 10
-  when: "'consul_token' not in ansible_facts or ansible_facts['consul_token'] == None"
+  - name: Start Consul service
+    ansible.builtin.systemd_service:
+      name: consul
+      state: started
+      enabled: false
 
-- name: Bootstrap Consul ACL
-  ansible.builtin.uri:
-    follow_redirects: none
-    force: true
-    method: PUT
-    return_content: true
-    unix_socket: /var/opt/nomad/run/consul.sock
-    url: http://localhost/v1/acl/bootstrap
-    use_netrc: false
-    use_proxy: false
-    validate_certs: false
-  register: consul_bootstrap
-  when: "'consul_token' not in ansible_facts or ansible_facts['consul_token'] == None"
+  - name: Wait for Consul socket to be available
+    ansible.builtin.wait_for:
+      path: /var/opt/nomad/run/consul.sock
+      state: present
+      timeout: 10
 
-- name: Write Consul configuration file with token
-  ansible.builtin.template:
-    src: consul.hcl
-    dest: /etc/consul.d/consul.hcl
-    owner: consul
-    group: consul
-    mode: '0600'
-    validate: consul validate -config-format=hcl %s
-  when: "'consul_token' not in ansible_facts or ansible_facts['consul_token'] == None"
+  - name: Bootstrap Consul ACL
+    ansible.builtin.uri:
+      follow_redirects: none
+      force: true
+      method: PUT
+      return_content: true
+      unix_socket: /var/opt/nomad/run/consul.sock
+      url: http://localhost/v1/acl/bootstrap
+      use_netrc: false
+      use_proxy: false
+      validate_certs: false
+    register: consul_bootstrap
+    # the raft leader election may not have completed at this point so bootstrap may fail
+    retries: 2
+    delay: 5
+    until: consul_bootstrap.status == 200
+
+  - name: Write Consul configuration file with token
+    ansible.builtin.template:
+      src: consul.hcl
+      dest: /etc/consul.d/consul.hcl
+      owner: consul
+      group: consul
+      mode: '0400'
+      validate: consul validate -config-format=hcl %s
 
 - name: Stop Consul service
   ansible.builtin.systemd_service:

--- a/roles/consul/templates/consul.hcl
+++ b/roles/consul/templates/consul.hcl
@@ -1,3 +1,5 @@
+{{ ansible_managed | comment }}
+
 datacenter = "{{ datacenter }}"
 
 data_dir = "/opt/consul"

--- a/roles/dhparam/tasks/main.yml
+++ b/roles/dhparam/tasks/main.yml
@@ -1,0 +1,38 @@
+---
+#
+# Generate Diffie-Hellman parameters
+# https://wiki.openssl.org/index.php/Diffie-Hellman_parameters
+#
+- name: Create dhparam Docker volume
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    unix_socket: /var/run/docker.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    method: POST
+    return_content: true
+    url: http://localhost/v1.43/volumes/create
+    body:
+      Name: dhparam
+    body_format: json
+    status_code:
+    - 201
+  register: docker_volume
+
+- name: Generate Diffie-Hellman parameters - this will take several minutes, be patient, drink some water
+  ansible.builtin.command:
+    argv:
+    - openssl
+    - dhparam
+    - -out
+    - "{{ docker_volume.json.Mountpoint }}/dhparam.pem"
+    - 4096
+    creates: "{{ docker_volume.json.Mountpoint }}/dhparam.pem"
+
+- name: Set permissions on Diffie-Hellman parameters
+  ansible.builtin.file:
+    path: "{{ docker_volume.json.Mountpoint }}/dhparam.pem"
+    state: file
+    mode: '0444'

--- a/roles/docker-system-prune/tasks/main.yml
+++ b/roles/docker-system-prune/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+#
+# Run docker system prune
+#
+- name: Run docker system prune
+  ansible.builtin.command:
+    argv:
+    - docker
+    - system
+    - prune
+    - --all
+    - --force
+  register: docker_system_prune_output
+  changed_when: >-
+    docker_system_prune_output.stdout != "Total reclaimed space: 0B"

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -62,3 +62,4 @@
     - --read-only
     - --rm
     - hello-world
+  changed_when: false

--- a/roles/firewall-rules/files/refresh-firewall-rules.nomad
+++ b/roles/firewall-rules/files/refresh-firewall-rules.nomad
@@ -1,0 +1,79 @@
+variable "region" {
+  type = string
+  description = "The region in which to run the service"
+}
+
+variable "datacenter" {
+  type = string
+  description = "The datacenter in which to run the service"
+}
+
+job "refresh-firewall-rules" {
+  region = var.region
+
+  datacenters = [var.datacenter]
+
+  type = "batch"
+
+  periodic {
+    cron = "0 6 * * *"
+    prohibit_overlap = true
+  }
+
+  group "refresh-firewall-rules" {
+    volume "firewall_rules" {
+      type = "host"
+      source = "firewall_rules"
+    }
+
+    task "refresh-firewall-rules" {
+      driver = "exec"
+
+      config {
+        command = "/bin/bash"
+        args = [
+          "-euxo",
+          "pipefail",
+          "-c",
+<<EOF
+cd ${NOMAD_TASK_DIR}
+curl --silent --http2-prior-knowledge --tlsv1.2 --location --output jq-linux64 https://github.com/jqlang/jq/releases/download/jq-1.6/jq-linux64
+curl --silent --http2-prior-knowledge --tlsv1.2 --location --output sha256sum.txt https://raw.githubusercontent.com/jqlang/jq/master/sig/v1.6/sha256sum.txt
+curl --silent --http2-prior-knowledge --tlsv1.2 --location --output uptime-robot.txt https://uptimerobot.com/inc/files/ips/IPv4.txt
+curl --silent --tlsv1.2 --location --output ip-ranges.json https://ip-ranges.amazonaws.com/ip-ranges.json
+grep jq-linux64 sha256sum.txt | sha256sum --status --warn --strict --check
+mv jq-linux64 jq
+chmod +x jq
+
+echo "# ${NOMAD_JOB_NAME}" > /firewall_rules/aws.conf
+for range in $(./jq -r '.prefixes[] | select(.region=="us-east-1") | select(.service=="EC2") | .ip_prefix' < ip-ranges.json)
+do
+    echo "allow $range;" >> /firewall_rules/aws.conf
+done
+
+echo "# ${NOMAD_JOB_NAME}" > /firewall_rules/uptime-robot.conf
+for range in $(cat uptime-robot.txt)
+do
+    echo "allow $(echo $range | tr -d '[:space:]');" >> /firewall_rules/uptime-robot.conf
+done
+
+ls -al /firewall_rules/
+
+cat /firewall_rules/*
+EOF
+        ]
+      }
+
+      resources {
+        cpu = 100
+        memory = 512
+        memory_max = 1024
+      }
+
+      volume_mount {
+        volume = "firewall_rules"
+        destination = "/firewall_rules/"
+      }
+    }
+  }
+}

--- a/roles/firewall-rules/tasks/main.yml
+++ b/roles/firewall-rules/tasks/main.yml
@@ -1,0 +1,114 @@
+---
+#
+# Set up "firewall rules"
+# These are pre-assembled lists of IP addresses and ranges that can be used in service configurations
+# to limit access to non-end-user-facing services
+#
+# Currently only supports IPv4 because our current production VLAN (128) only has IPv4 addressing
+#
+- name: Copy VPN rules to target
+  ansible.builtin.template:
+    src: vpn.conf
+    dest: /var/opt/nomad/firewall_rules/vpn.conf
+    owner: root
+    group: root
+    mode: '0444'
+
+- name: Copy local rules to target
+  ansible.builtin.template:
+    src: local.conf
+    dest: /var/opt/nomad/firewall_rules/local.conf
+    owner: root
+    group: root
+    mode: '0444'
+
+- name: Generate job JSON
+  ansible.builtin.command:
+    argv:
+    - nomad
+    - job
+    - run
+    - -no-color
+    - -output
+    - -var
+    - region={{ region }}
+    - -var
+    - datacenter={{ datacenter }}
+    - "-"
+    stdin: "{{ lookup('ansible.builtin.file', './refresh-firewall-rules.nomad') }}"
+  register: nomad_job_json
+  changed_when: false
+
+- name: Submit job to Nomad
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    body: "{{ nomad_job_json.stdout }}"
+    body_format: json
+    method: POST
+    url: http://127.0.0.1:4646/v1/jobs
+
+- name: Check if aws rules are already present
+  ansible.builtin.stat:
+    path: /var/opt/nomad/firewall_rules/aws.conf
+  register: aws_rules
+
+- name: Check if uptime-robot rules are already present
+  ansible.builtin.stat:
+    path: /var/opt/nomad/firewall_rules/uptime-robot.conf
+  register: uptime_robot_rules
+
+- name: Manually launch the job to generate dynamic rules
+  when: not aws_rules.stat.exists or not uptime_robot_rules.stat.exists
+  block:
+
+  - name: Force launch the job
+    ansible.builtin.uri:
+      follow_redirects: none
+      force: true
+      use_netrc: false
+      use_proxy: false
+      validate_certs: false
+      return_content: true
+      headers:
+        X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+      method: POST
+      url: http://127.0.0.1:4646/v1/job/refresh-firewall-rules/periodic/force
+    register: force_launch_output
+
+  - name: List allocations for evaluation
+    ansible.builtin.uri:
+      follow_redirects: none
+      force: true
+      use_netrc: false
+      use_proxy: false
+      validate_certs: false
+      return_content: true
+      headers:
+        X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+      method: GET
+      url: http://127.0.0.1:4646/v1/evaluation/{{ force_launch_output.json.EvalID }}/allocations
+    register: evaluation_output
+
+  - name: Wait for allocation to complete
+    ansible.builtin.uri:
+      follow_redirects: none
+      force: true
+      use_netrc: false
+      use_proxy: false
+      validate_certs: false
+      return_content: true
+      headers:
+        X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+      method: GET
+      url: http://127.0.0.1:4646/v1/allocation/{{ evaluation_output.json[0].ID }}
+    register: allocation_output
+    until: allocation_output.json.ClientStatus == "complete"
+    retries: 5
+    delay: 2

--- a/roles/firewall-rules/templates/.gitattributes
+++ b/roles/firewall-rules/templates/.gitattributes
@@ -1,0 +1,1 @@
+*.conf linguist-language=Nginx

--- a/roles/firewall-rules/templates/local.conf
+++ b/roles/firewall-rules/templates/local.conf
@@ -1,0 +1,4 @@
+{{ ansible_managed | comment }}
+
+allow {{ ansible_host }};
+allow 127.0.0.0/8;

--- a/roles/firewall-rules/templates/vpn.conf
+++ b/roles/firewall-rules/templates/vpn.conf
@@ -1,0 +1,21 @@
+{{ ansible_managed | comment }}
+
+# vpn-2fa-csrplus
+allow 10.2.116.0/24;
+allow 10.2.242.0/24;
+
+# vpn-2fa-employees
+allow 10.2.64.0/19;
+allow 10.2.192.0/19;
+
+# vpn-2fa-former-emp
+allow 10.2.121.0/24;
+allow 10.2.244.0/24;
+
+# vpn-2fa-students
+allow 10.2.0.0/18;
+allow 10.2.128.0/18;
+
+# vpn-2fa-other
+allow 10.2.117.0/24;
+allow 10.2.243.0/24;

--- a/roles/nginx/files/nginx.nomad
+++ b/roles/nginx/files/nginx.nomad
@@ -1,0 +1,311 @@
+variable "region" {
+  type = string
+  description = "The region in which to run the service"
+}
+
+variable "datacenter" {
+  type = string
+  description = "The datacenter in which to run the service"
+}
+
+variable "certificate_volume" {
+  type = string
+  description = "The Docker volume to mount, containing a certificate"
+}
+
+job "nginx" {
+  region = var.region
+
+  datacenters = [var.datacenter]
+
+  type = "service"
+
+  group "nginx" {
+    volume "firewall_rules" {
+      type = "host"
+      source = "firewall_rules"
+    }
+
+    volume "run" {
+      type = "host"
+      source = "run"
+    }
+
+    network {
+      port "http" {
+        static = 80
+      }
+      port "https" {
+        static = 443
+      }
+    }
+
+    task "nginx" {
+      config {
+        image = "nginx"
+
+        force_pull = true
+
+        network_mode = "host"
+
+        mount {
+          type   = "bind"
+          source = "local/"
+          target = "/etc/nginx/conf.d/"
+          readonly = true
+        }
+
+        mount {
+          type = "tmpfs"
+          target = "/var/cache/nginx/"
+          readonly = false
+          tmpfs_options {
+            size = 1000000000
+          }
+        }
+
+        mount {
+          type = "volume"
+          target = "/certificate/"
+          source = var.certificate_volume
+          readonly = true
+
+          volume_options {
+            no_copy = true
+          }
+        }
+
+        mount {
+          type = "volume"
+          target = "/assets/"
+          source = "assets"
+          readonly = true
+
+          volume_options {
+            no_copy = true
+          }
+        }
+
+        mount {
+          type = "volume"
+          target = "/dhparam/"
+          source = "dhparam"
+          readonly = true
+
+          volume_options {
+            no_copy = true
+          }
+        }
+      }
+
+      driver = "docker"
+
+      resources {
+        cpu = 1000
+        memory = 512
+        memory_max = 1024
+      }
+
+      volume_mount {
+        volume = "run"
+        destination = "/var/opt/nomad/run/"
+      }
+
+      volume_mount {
+        volume = "firewall_rules"
+        destination = "/etc/nginx/firewall_rules/"
+        read_only = true
+      }
+
+      template {
+        data = <<EOH
+{{- range services -}}
+  {{- range service .Name -}}
+    {{- if .Tags | contains "http" -}}
+      {{- scratch.Set "registerService" .Name -}}
+    {{- else if index .ServiceMeta "socket" -}}
+      {{- scratch.Set "registerService" .Name -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- if eq .Name (scratch.Get "registerService") -}}
+upstream {{ .Name }} {
+  {{- range service .Name -}}
+    {{- if index .ServiceMeta "socket" }}
+  server unix:{{- index .ServiceMeta "socket" -}};{{- else if .Tags | contains "http" }}
+  server 127.0.0.1:{{ .Port }};{{ end -}}
+  {{- end }}
+
+    keepalive 8;
+}
+
+{{ end -}}
+{{- end -}}
+{{ if not (service "vouch") }}
+upstream vouch {
+  server 127.0.0.1:65535 down;
+}
+{{ end }}
+{{ range safeLs "nginx/config" }}
+{{ .Value }}
+{{ end }}
+{{ range $service, $hostname := (key "nginx/hostnames" | parseJSON) }}
+server {
+  server_name {{ $hostname }};
+
+  listen {{ env "NOMAD_PORT_http" }};
+  listen [::]:{{ env "NOMAD_PORT_http" }};
+
+  return 301 https://{{ $hostname }}$request_uri;
+}
+{{ if not (service $service) }}
+server {
+  server_name {{ $hostname }};
+
+  listen {{ env "NOMAD_PORT_https" }} ssl;
+  listen [::]:{{ env "NOMAD_PORT_https" }} ssl;
+  http2 on;
+
+  listen {{ env "NOMAD_PORT_https" }} quic;
+  listen [::]:{{ env "NOMAD_PORT_https" }} quic;
+  http3 on;
+  http3_hq on;
+
+  return 503;
+
+  add_header X-Frame-Options DENY always;
+  add_header X-Content-Type-Options nosniff always;
+  add_header Referrer-Policy no-referrer always;
+  add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+  add_header Alt-Svc 'h3=":{{ env "NOMAD_PORT_https" }}"; ma=86400' always;
+}
+{{- else -}}
+{{- range service $service -}}
+{{- if index .ServiceMeta "nginx-config" }}
+server {
+  server_name {{ $hostname }};
+
+  listen {{ env "NOMAD_PORT_https" }} ssl;
+  listen [::]:{{ env "NOMAD_PORT_https" }} ssl;
+  http2 on;
+
+  listen {{ env "NOMAD_PORT_https" }} quic;
+  listen [::]:{{ env "NOMAD_PORT_https" }} quic;
+  http3 on;
+  http3_hq on;
+
+  root /assets/{{ $service }};
+
+  {{- index .ServiceMeta "nginx-config" -}}
+
+  {{- if not (index .ServiceMeta "no-default-headers") -}}
+  {{- if index .ServiceMeta "x-frame-options" -}}
+  add_header X-Frame-Options {{ index .ServiceMeta "x-frame-options" }} always;
+  {{- else -}}
+  add_header X-Frame-Options DENY always;
+  {{- end -}}
+  add_header X-Content-Type-Options nosniff always;
+  {{- if index .ServiceMeta "referrer-policy" -}}
+  add_header Referrer-Policy {{ index .ServiceMeta "referrer-policy" }} always;
+  {{- else -}}
+  add_header Referrer-Policy no-referrer always;
+  {{- end -}}
+  add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+  {{- end -}}
+  add_header Alt-Svc 'h3=":{{ env "NOMAD_PORT_https" }}"; ma=86400' always;
+
+  {{- if index .ServiceMeta "firewall-rules" -}}
+    {{- range (index .ServiceMeta "firewall-rules" | parseJSON) -}}
+      {{- if eq . "internet" }}
+  allow all;
+      {{- else }}
+  include firewall_rules/{{- . -}}.conf;
+      {{- end -}}
+    {{- end -}}
+  {{- end }}
+  deny all;
+}
+{{ end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+EOH
+
+        change_mode = "signal"
+        change_signal = "SIGHUP"
+
+        destination = "local/nginx.conf"
+      }
+
+      service {
+        name = "nginx"
+
+        port = "http"
+
+        tags = [
+          "http"
+        ]
+
+        check {
+          success_before_passing = 3
+          failures_before_critical = 2
+
+          interval = "5s"
+
+          name = "HTTP"
+          path = "/ping"
+          port = "http"
+          protocol = "http"
+          timeout = "1s"
+          type = "http"
+        }
+
+        check_restart {
+          limit = 5
+          grace = "20s"
+        }
+      }
+
+      service {
+        name = "nginx"
+
+        port = "https"
+
+        tags = [
+          "https"
+        ]
+
+        check {
+          success_before_passing = 3
+          failures_before_critical = 2
+
+          interval = "5s"
+
+          name = "HTTPS"
+          path = "/ping"
+          port = "https"
+          protocol = "https"
+          tls_skip_verify = true
+          timeout = "1s"
+          type = "http"
+        }
+
+        check_restart {
+          limit = 5
+          grace = "20s"
+        }
+      }
+
+      restart {
+        attempts = 5
+        delay = "10s"
+        interval = "1m"
+        mode = "fail"
+      }
+    }
+  }
+
+  update {
+    max_parallel = 0
+  }
+}

--- a/roles/nginx/meta/main.yml
+++ b/roles/nginx/meta/main.yml
@@ -1,0 +1,2 @@
+---
+allow_duplicates: true

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -1,0 +1,403 @@
+---
+#
+# Manages the nginx job within Nomad
+# https://nginx.org/
+#
+- name: Check for existing hostnames map within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/kv/nginx/hostnames
+    status_code:
+    - 200
+    - 404
+  register: hostnames_map
+
+- name: Store initial hostnames map within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    body:
+      # consul is deliberately not included here because its service registration is weird and different
+      # so we have to manually configure the whole thing
+      nomad: "nomad.{{ datacenter }}.robojackets.net"
+      registry: "registry.{{ datacenter }}.robojackets.net"
+      vouch: "vouch.{{ datacenter }}.robojackets.net"
+    body_format: json
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: PUT
+    url: http://localhost/v1/kv/nginx/hostnames
+  when: hostnames_map.status == 404
+  changed_when: true
+
+- name: Check for existing baseline config within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/kv/nginx/config/00-baseline
+    status_code:
+    - 200
+    - 404
+  register: baseline_config
+
+- name: Store baseline config within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    body: "{{ lookup('ansible.builtin.template', './00-baseline.conf') }}"
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: PUT
+    url: http://localhost/v1/kv/nginx/config/00-baseline
+  when: baseline_config.status == 404 or lookup('ansible.builtin.template', './00-baseline.conf') != (baseline_config.json.0.Value | b64decode)
+  changed_when: true
+
+- name: Retrieve ACME account thumbprint from Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/kv/acme/{{ acme_server }}-thumbprint
+  register: acme_account_thumbprint_consul
+
+- name: Check for existing default HTTP server config within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/kv/nginx/config/01-default-http
+    status_code:
+    - 200
+    - 404
+  register: default_http
+
+- name: Store default HTTP server config within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    body: "{{ lookup('ansible.builtin.template', './01-default-http.conf') }}"
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: PUT
+    url: http://localhost/v1/kv/nginx/config/01-default-http
+  when: default_http.status == 404 or lookup('ansible.builtin.template', './01-default-http.conf') != (default_http.json.0.Value | b64decode)
+  changed_when: true
+
+- name: Check for existing default HTTPS server config within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/kv/nginx/config/02-default-https
+    status_code:
+    - 200
+    - 404
+  register: default_https
+
+- name: Store default HTTPS server config within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    body: "{{ lookup('ansible.builtin.template', './02-default-https.conf') }}"
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: PUT
+    url: http://localhost/v1/kv/nginx/config/02-default-https
+  when: default_https.status == 404 or lookup('ansible.builtin.template', './02-default-https.conf') != (default_https.json.0.Value | b64decode)
+  changed_when: true
+
+- name: Check if Vouch is available
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/health/checks/vouch
+  register: vouch_service_status
+
+- name: Check for existing Consul server config within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/kv/nginx/config/03-consul
+    status_code:
+    - 200
+    - 404
+  register: consul_server
+
+- name: Store Consul server config within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    body: "{{ lookup('ansible.builtin.template', './03-consul.conf') }}"
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: PUT
+    url: http://localhost/v1/kv/nginx/config/03-consul
+  when: consul_server.status == 404 or lookup('ansible.builtin.template', './03-consul.conf') != (consul_server.json.0.Value | b64decode)
+  changed_when: true
+
+- name: Check for existing Nomad server config within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/kv/nginx/config/04-nomad
+    status_code:
+    - 200
+    - 404
+  register: nomad_server
+
+- name: Store Nomad server config within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    body: "{{ lookup('ansible.builtin.template', './04-nomad.conf') }}"
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: PUT
+    url: http://localhost/v1/kv/nginx/config/04-nomad
+  when: nomad_server.status == 404 or lookup('ansible.builtin.template', './04-nomad.conf') != (nomad_server.json.0.Value | b64decode)
+  changed_when: true
+
+- name: Create assets Docker volume
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    unix_socket: /var/run/docker.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    method: POST
+    return_content: true
+    url: http://localhost/v1.43/volumes/create
+    body:
+      Name: assets
+    body_format: json
+    status_code:
+    - 201
+  register: assets_volume
+
+- name: Set permissions on assets volume
+  ansible.builtin.file:
+    path: "{{ docker_volume.json.Mountpoint }}/"
+    state: directory
+    mode: '0777'
+
+- name: Check for ACME certificate from {{ acme_server }}
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    unix_socket: /var/run/docker.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    method: GET
+    return_content: true
+    url: http://localhost/v1.43/volumes/acme-certificate-{{ acme_server }}
+    status_code:
+    - 200
+    - 404
+  register: acme_certificate_volume
+
+- name: Check to make sure CA certificate is loaded in the volume
+  ansible.builtin.stat:
+    path: "{{ acme_certificate_volume.json.Mountpoint }}/ca.pem"
+  when: acme_certificate_volume.status == 200
+  register: ca_cert
+
+- name: Check to make sure chained server certificate is loaded in the volume
+  ansible.builtin.stat:
+    path: "{{ acme_certificate_volume.json.Mountpoint }}/fullchain.pem"
+  when: acme_certificate_volume.status == 200
+  register: server_cert
+
+- name: Check to make sure private key is loaded in the volume
+  ansible.builtin.stat:
+    path: "{{ acme_certificate_volume.json.Mountpoint }}/key.pem"
+  when: acme_certificate_volume.status == 200
+  register: key
+
+- name: Generate job submission JSON
+  ansible.builtin.command:
+    argv:
+    - nomad
+    - job
+    - run
+    - -no-color
+    - -output
+    - -var
+    - region={{ region }}
+    - -var
+    - datacenter={{ datacenter }}
+    - -var
+    - certificate_volume={% if acme_certificate_volume.status == 200 and ca_cert.stat.exists and server_cert.stat.exists and key.stat.exists %}acme-certificate-{{ acme_server }}{% else %}self-signed-certificate{% endif %}
+    - "-"
+    stdin: "{{ lookup('ansible.builtin.file', './nginx.nomad') }}"
+  register: nomad_job_json
+  changed_when: false
+
+- name: Submit job to Nomad
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    body: "{{ nomad_job_json.stdout }}"
+    body_format: json
+    method: POST
+    url: http://127.0.0.1:4646/v1/jobs
+  register: job_register_output
+
+- name: List allocations for evaluation
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: GET
+    url: http://127.0.0.1:4646/v1/evaluation/{{ job_register_output.json.EvalID }}/allocations
+  register: allocations_output
+
+- name: Wait for container to start
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: GET
+    url: http://127.0.0.1:4646/v1/allocation/{{ allocations_output.json[0].ID }}
+  register: allocation_output
+  until: allocation_output.json.TaskStates.nginx.State == "running"
+  retries: 5
+  delay: 2
+  when: (allocations_output.json | length) > 0
+
+- name: Wait for port 80 to be listening
+  ansible.builtin.wait_for:
+    port: 80
+    timeout: 30
+
+- name: Wait for port 443 to be listening
+  ansible.builtin.wait_for:
+    port: 443
+    timeout: 30
+
+- name: Wait for health checks in Consul to be passing
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/health/checks/nginx
+  register: service_status
+  until: service_status.json[0].Status == "passing" and service_status.json[1].Status == "passing"
+  retries: 5
+  delay: 2

--- a/roles/nginx/templates/.gitattributes
+++ b/roles/nginx/templates/.gitattributes
@@ -1,0 +1,1 @@
+*.conf linguist-language=Nginx

--- a/roles/nginx/templates/00-baseline.conf
+++ b/roles/nginx/templates/00-baseline.conf
@@ -1,0 +1,19 @@
+{{ ansible_managed | comment }}
+
+server_tokens off;
+
+gzip on;
+gzip_comp_level 9;
+gzip_types text/css application/javascript image/svg+xml;
+
+open_file_cache max=1000 inactive=20s;
+open_file_cache_valid 30s;
+open_file_cache_min_uses 2;
+open_file_cache_errors on;
+
+proxy_http_version 1.1;
+
+proxy_cache_revalidate on;
+
+proxy_cache_path /var/cache/nginx/vouch_assets/ use_temp_path=off keys_zone=vouch_assets:1m inactive=24h;
+proxy_cache_path /var/cache/nginx/vouch_auth/ use_temp_path=off keys_zone=vouch_auth:1m inactive=24h;

--- a/roles/nginx/templates/01-default-http.conf
+++ b/roles/nginx/templates/01-default-http.conf
@@ -1,0 +1,32 @@
+{{ ansible_managed | comment }}
+
+server {
+  server_name _;
+
+  listen 80 default_server;
+  listen [::]:80 default_server;
+
+  location ~ ^/\.well-known/acme-challenge/([-_a-zA-Z0-9]+)$ {
+    default_type text/plain;
+    return 200 "$1.{{ (acme_account_thumbprint_consul.json.0.Value | b64decode) }}";
+  }
+
+  location = /ping {
+    return 204;
+    access_log off;
+  }
+
+  location = / {
+    default_type text/html;
+    return 200 "{{ lookup('ansible.builtin.template', './index.html') | replace('"', '\\"') }}";
+  }
+
+  location / {
+    return 404;
+  }
+
+  add_header Content-Security-Policy "default-src 'none'; style-src 'unsafe-hashes' 'sha256-/Jq13Fubhge9Eku4fvCTfYzrGeMCPgJ0Ep6mZ5NAHP8='";
+  add_header X-Frame-Options DENY always;
+  add_header X-Content-Type-Options nosniff always;
+  add_header Referrer-Policy no-referrer always;
+}

--- a/roles/nginx/templates/02-default-https.conf
+++ b/roles/nginx/templates/02-default-https.conf
@@ -1,0 +1,54 @@
+{{ ansible_managed | comment }}
+
+server {
+  server_name _;
+
+  listen 443 quic reuseport default_server;
+  listen [::]:443 quic reuseport default_server;
+  http3 on;
+  http3_hq on;
+
+  listen 443 ssl default_server;
+  listen [::]:443 ssl default_server;
+  http2 on;
+
+  ssl_prefer_server_ciphers on;
+  ssl_ecdh_curve secp384r1;
+  ssl_session_cache shared:SSL:10m;
+  ssl_session_timeout 5m;
+  ssl_session_tickets off;
+  ssl_stapling on;
+  ssl_stapling_verify on;
+  ssl_protocols TLSv1.2 TLSv1.3;
+  ssl_ciphers EECDH+AESGCM:EDH+AESGCM;
+
+  ssl_dhparam /dhparam/dhparam.pem;
+
+  resolver {{ dns_resolvers | join (' ') }};
+  resolver_timeout 1s;
+
+  ssl_trusted_certificate /certificate/ca.pem;
+  ssl_certificate /certificate/fullchain.pem;
+  ssl_certificate_key /certificate/key.pem;
+
+  add_header Content-Security-Policy "default-src 'none'; style-src 'unsafe-hashes' 'sha256-/Jq13Fubhge9Eku4fvCTfYzrGeMCPgJ0Ep6mZ5NAHP8='";
+  add_header X-Frame-Options DENY always;
+  add_header X-Content-Type-Options nosniff always;
+  add_header Referrer-Policy no-referrer always;
+  add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
+  add_header Alt-Svc 'h3=":443"; ma=86400' always;
+
+  location = /ping {
+    return 204;
+    access_log off;
+  }
+
+  location = / {
+    default_type text/html;
+    return 200 "{{ lookup('ansible.builtin.template', './index.html') | replace('"', '\\"') }}";
+  }
+
+  location / {
+    return 404;
+  }
+}

--- a/roles/nginx/templates/03-consul.conf
+++ b/roles/nginx/templates/03-consul.conf
@@ -1,0 +1,127 @@
+{{ ansible_managed | comment }}
+
+proxy_cache_path /var/cache/nginx/consul_assets/ use_temp_path=off keys_zone=consul_assets:1m inactive=24h;
+proxy_cache_path /var/cache/nginx/consul_token_auth/ use_temp_path=off keys_zone=consul_token_auth:1m inactive=24h;
+
+upstream consul {
+    server unix:/var/opt/nomad/run/consul.sock;
+}
+
+server {
+  server_name consul.{{ datacenter }}.robojackets.net;
+
+  listen 80;
+  listen [::]:80;
+
+  return 301 https://consul.{{ datacenter }}.robojackets.net$request_uri;
+}
+
+server {
+  server_name consul.{{ datacenter }}.robojackets.net;
+
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  http2 on;
+
+  listen 443 quic;
+  listen [::]:443 quic;
+  http3 on;
+  http3_hq on;
+
+  location /ui/assets/ {
+    proxy_pass http://consul;
+    proxy_pass_request_headers off;
+    proxy_pass_request_body off;
+
+    proxy_cache consul_assets;
+    proxy_cache_valid 24h;
+
+    add_header X-Cache-Status $upstream_cache_status;
+    allow all;
+  }
+
+  location / {
+    proxy_pass http://consul;
+    proxy_read_timeout 360s;
+    proxy_set_header Connection "";
+  }
+
+  location = /v1/acl/token/self {
+    proxy_pass http://consul;
+    proxy_pass_request_headers off;
+    proxy_pass_request_body off;
+
+    proxy_read_timeout 5s;
+
+    proxy_set_header X-Consul-Token $http_x_consul_token;
+
+    proxy_cache_valid 200 24h;
+    proxy_cache consul_token_auth;
+    proxy_cache_methods GET;
+    proxy_cache_key $http_x_consul_token;
+  }
+
+  location /v1/ {
+    proxy_pass http://consul;
+    proxy_read_timeout 360s;
+    proxy_set_header Connection "";
+
+    auth_request /v1/acl/token/self;
+  }
+
+{% if vouch_service_status.status == 200 and (vouch_service_status.json | length) > 0 and vouch_service_status.json[0].Status == "passing" %}
+
+  location = /v1/internal/acl/authorize {
+    proxy_pass http://consul;
+    proxy_read_timeout 360s;
+    proxy_set_header Connection "";
+
+    auth_request /validate;
+  }
+
+  location = /v1/catalog/datacenters {
+    proxy_pass http://consul;
+    proxy_read_timeout 360s;
+    proxy_set_header Connection "";
+
+    auth_request /validate;
+  }
+
+  satisfy any;
+
+  auth_request /validate;
+
+  location = /validate {
+    internal;
+
+    proxy_pass http://vouch;
+
+    proxy_set_header Host $http_host;
+
+    proxy_pass_request_body off;
+    proxy_set_header Content-Length "";
+
+    proxy_cache_valid 200 1h;
+    proxy_cache vouch_auth;
+    proxy_cache_methods GET;
+    proxy_cache_key $cookie_vouchcookie;
+
+    auth_request_set $auth_resp_jwt $upstream_http_x_vouch_jwt;
+    auth_request_set $auth_resp_err $upstream_http_x_vouch_err;
+    auth_request_set $auth_resp_failcount $upstream_http_x_vouch_failcount;
+  }
+
+  error_page 401 = @error401;
+
+  location @error401 {
+    return 302 https://vouch.{{ datacenter }}.robojackets.net/login?url=https://consul.{{ datacenter }}.robojackets.net$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
+  }
+
+{% endif %}
+
+  add_header Alt-Svc 'h3=":443"; ma=86400' always;
+
+  include firewall_rules/vpn.conf;
+  include firewall_rules/uptime-robot.conf;
+  deny all;
+}

--- a/roles/nginx/templates/04-nomad.conf
+++ b/roles/nginx/templates/04-nomad.conf
@@ -1,0 +1,150 @@
+{{ ansible_managed | comment }}
+
+proxy_cache_path /var/cache/nginx/nomad_assets/ use_temp_path=off keys_zone=nomad_assets:1m inactive=24h;
+proxy_cache_path /var/cache/nginx/nomad_token_auth/ use_temp_path=off keys_zone=nomad_token_auth:1m inactive=24h;
+
+server {
+  server_name nomad.{{ datacenter }}.robojackets.net;
+
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  http2 on;
+
+  listen 443 quic;
+  listen [::]:443 quic;
+  http3 on;
+  http3_hq on;
+
+  location / {
+    proxy_pass http://nomad;
+    proxy_read_timeout 360s;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_buffering off;
+    proxy_set_header Origin "${scheme}://${proxy_host}";
+  }
+
+  location /v1/acl/auth-methods {
+    proxy_pass http://nomad;
+    proxy_read_timeout 360s;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_buffering off;
+    proxy_set_header Origin "${scheme}://${proxy_host}";
+
+    allow all;
+  }
+
+  location = /v1/acl/token/self {
+    proxy_pass http://nomad;
+    proxy_pass_request_headers off;
+    proxy_pass_request_body off;
+
+    proxy_read_timeout 5s;
+
+    proxy_set_header X-Nomad-Token $http_x_nomad_token;
+
+    proxy_cache_valid 200 24h;
+    proxy_cache nomad_token_auth;
+    proxy_cache_methods GET;
+    proxy_cache_key $http_x_nomad_token;
+
+    proxy_intercept_errors on;
+
+    error_page 500 =403 /error/403;
+  }
+
+  location /v1/ {
+    proxy_pass http://nomad;
+    proxy_read_timeout 360s;
+    proxy_set_header Connection "";
+
+    auth_request /v1/acl/token/self;
+  }
+
+  location /ui/assets/ {
+    proxy_pass http://nomad;
+    proxy_pass_request_headers off;
+    proxy_pass_request_body off;
+
+    proxy_cache nomad_assets;
+    proxy_cache_valid 24h;
+
+    add_header X-Cache-Status $upstream_cache_status;
+    allow all;
+  }
+
+  location = /ui//favicon.ico {
+    proxy_pass http://nomad;
+    proxy_pass_request_headers off;
+    proxy_pass_request_body off;
+
+    proxy_cache nomad_assets;
+    proxy_cache_valid 24h;
+
+    add_header X-Cache-Status $upstream_cache_status;
+    allow all;
+  }
+
+  location = /ui/favicon.ico {
+    proxy_pass http://nomad;
+    proxy_pass_request_headers off;
+    proxy_pass_request_body off;
+
+    proxy_cache nomad_assets;
+    proxy_cache_valid 24h;
+
+    add_header X-Cache-Status $upstream_cache_status;
+    allow all;
+  }
+
+  location = /error/403 {
+    internal;
+    return 403;
+  }
+
+  add_header X-Frame-Options DENY always;
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+  add_header X-Content-Type-Options nosniff always;
+  add_header Referrer-Policy no-referrer always;
+
+{% if vouch_service_status.status == 200 and (vouch_service_status.json | length) > 0 and vouch_service_status.json[0].Status == "passing" %}
+
+  satisfy any;
+
+  auth_request /validate;
+
+  location = /validate {
+    proxy_pass http://vouch;
+
+    proxy_set_header Host $http_host;
+
+    proxy_pass_request_body off;
+    proxy_set_header Content-Length "";
+
+    proxy_cache_valid 200 1h;
+    proxy_cache vouch_auth;
+    proxy_cache_methods GET;
+    proxy_cache_key $cookie_vouchcookie;
+
+    auth_request_set $auth_resp_jwt $upstream_http_x_vouch_jwt;
+    auth_request_set $auth_resp_err $upstream_http_x_vouch_err;
+    auth_request_set $auth_resp_failcount $upstream_http_x_vouch_failcount;
+  }
+
+  error_page 401 = @error401;
+
+  location @error401 {
+    return 302 https://vouch.{{ datacenter }}.robojackets.net/login?url=https://nomad.{{ datacenter }}.robojackets.net$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
+  }
+
+{% endif %}
+
+  add_header Alt-Svc 'h3=":443"; ma=86400' always;
+
+  include firewall_rules/vpn.conf;
+  include firewall_rules/uptime-robot.conf;
+  deny all;
+}

--- a/roles/nginx/templates/index.html
+++ b/roles/nginx/templates/index.html
@@ -1,0 +1,1 @@
+<html><head><title>{{ node_name }}</title></head><body style="font-family: sans-serif"><h1>{{ node_name }}</h1>This is <a href="https://{{ fully_qualified_domain_name }}">{{ fully_qualified_domain_name }}</a>. This system is managed by <a href="mailto:{{ owner_contact_email }}">{{ owner_contact_name }}</a>.</body></html>

--- a/roles/nomad/tasks/main.yml
+++ b/roles/nomad/tasks/main.yml
@@ -5,11 +5,41 @@
 #
 # Assumes Consul role already executed successfully
 #
+- name: Create /var/opt/nomad/firewall_rules/
+  ansible.builtin.file:
+    path: /var/opt/nomad/firewall_rules/
+    state: directory
+    mode: '0555'
+
+- name: Create /root/.docker/
+  ansible.builtin.file:
+    path: /root/.docker/
+    state: directory
+    mode: '0500'
+
+- name: Write placeholder Docker config file
+  ansible.builtin.copy:
+    content: "{}"
+    dest: /root/.docker/config.json
+    force: false
+    owner: root
+    group: root
+    mode: '0400'
+
 - name: Install Nomad
   ansible.builtin.yum:
     name:
     - nomad
     state: present
+
+- name: Write Nomad service file
+  ansible.builtin.template:
+    src: nomad.service
+    dest: /lib/systemd/system/nomad.service
+    owner: root
+    group: root
+    mode: '0644'
+  register: nomad_service
 
 - name: Write Nomad configuration file
   ansible.builtin.template:
@@ -17,9 +47,17 @@
     dest: /etc/nomad.d/nomad.hcl
     owner: nomad
     group: nomad
-    mode: '0600'
+    mode: '0400'
     validate: nomad config validate %s
   register: nomad_hcl_template
+
+- name: Stop Nomad service
+  ansible.builtin.systemd_service:
+    daemon_reload: true
+    name: nomad
+    state: stopped
+    enabled: false
+  when: nomad_service.changed or nomad_hcl_template.changed
 
 - name: Start Nomad service
   ansible.builtin.systemd_service:
@@ -69,6 +107,10 @@
     url: http://127.0.0.1:4646/v1/acl/bootstrap
   register: nomad_bootstrap
   when: nomad_token_present.status == 404
+  # the raft leader election may not have completed at this point so bootstrap may fail
+  retries: 2
+  delay: 5
+  until: nomad_bootstrap.status == 200
 
 - name: Set Nomad token as fact
   ansible.builtin.set_fact:

--- a/roles/nomad/templates/nomad.hcl
+++ b/roles/nomad/templates/nomad.hcl
@@ -1,3 +1,5 @@
+{{ ansible_managed | comment }}
+
 datacenter = "{{ datacenter }}"
 
 data_dir = "/opt/nomad"
@@ -6,6 +8,10 @@ server {
   enabled = true
 
   bootstrap_expect = 1
+
+  default_scheduler_config {
+    memory_oversubscription_enabled = true
+  }
 }
 
 bind_addr = "127.0.0.1"
@@ -28,6 +34,10 @@ client {
 
   host_volume "run" {
     path = "/var/opt/nomad/run/"
+  }
+
+  host_volume "firewall_rules" {
+    path = "/var/opt/nomad/firewall_rules/"
   }
 }
 
@@ -59,10 +69,10 @@ plugin "docker" {
     # https://developer.hashicorp.com/nomad/docs/drivers/docker#allow_caps - defaults + sys_nice for mysql
     allow_caps = ["audit_write", "chown", "dac_override", "fowner", "fsetid", "kill", "mknod",
                   "net_bind_service", "setfcap", "setgid", "setpcap", "setuid", "sys_chroot", "sys_nice"]
-  }
 
-  volumes {
-    enabled = true
+    volumes {
+      enabled = true
+    }
   }
 }
 

--- a/roles/nomad/templates/nomad.service
+++ b/roles/nomad/templates/nomad.service
@@ -1,0 +1,45 @@
+{{ ansible_managed | comment }}
+
+[Unit]
+Description=Nomad
+Documentation=https://nomadproject.io/docs/
+Wants=network-online.target
+After=network-online.target
+
+Wants=consul.service
+After=consul.service
+
+Wants=docker.service
+After=docker.service
+
+[Service]
+EnvironmentFile=-/etc/nomad.d/nomad.env
+ExecReload=/bin/kill -HUP $MAINPID
+ExecStart=/usr/bin/nomad agent -config /etc/nomad.d
+KillMode=process
+KillSignal=SIGINT
+LimitNOFILE=65536
+LimitNPROC=infinity
+Restart=on-failure
+RestartSec=2
+
+## Configure unit start rate limiting. Units which are started more than
+## *burst* times within an *interval* time span are not permitted to start any
+## more. Use `StartLimitIntervalSec` or `StartLimitInterval` (depending on
+## systemd version) to configure the checking interval and `StartLimitBurst`
+## to configure how many starts per interval are allowed. The values in the
+## commented lines are defaults.
+
+# StartLimitBurst = 5
+
+## StartLimitIntervalSec is used for systemd versions >= 230
+# StartLimitIntervalSec = 10s
+
+## StartLimitInterval is used for systemd versions < 230
+# StartLimitInterval = 10s
+
+TasksMax=infinity
+OOMScoreAdjust=-1000
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/self-signed-certificate/tasks/main.yml
+++ b/roles/self-signed-certificate/tasks/main.yml
@@ -1,0 +1,69 @@
+---
+#
+# Generate a self-signed certificate for use with bootstrapping Nginx
+# https://unix.stackexchange.com/a/104305
+#
+- name: Create self-signed-certificate Docker volume
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    unix_socket: /var/run/docker.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    method: POST
+    return_content: true
+    url: http://localhost/v1.43/volumes/create
+    body:
+      Name: self-signed-certificate
+    body_format: json
+    status_code:
+    - 201
+  register: docker_volume
+
+- name: Generate self-signed certificate
+  ansible.builtin.command:
+    argv:
+    - openssl
+    - req
+    - -new
+    - -newkey
+    - rsa:4096
+    - -days
+    - 365
+    - -nodes
+    - -x509
+    - -subj
+    - "/C=US/ST=Georgia/L=Atlanta/O=RoboJackets/CN={{ fully_qualified_domain_name }}"
+    - -keyout
+    - "{{ docker_volume.json.Mountpoint }}/key.pem"
+    - -out
+    - "{{ docker_volume.json.Mountpoint }}/fullchain.pem"
+    creates: "{{ docker_volume.json.Mountpoint }}/key.pem"
+
+- name: Set permissions on volume
+  ansible.builtin.file:
+    path: "{{ docker_volume.json.Mountpoint }}/"
+    state: directory
+    mode: '0555'
+
+- name: Set permissions on private key
+  ansible.builtin.file:
+    path: "{{ docker_volume.json.Mountpoint }}/key.pem"
+    state: file
+    mode: '0444'
+
+- name: Set permissions on certificate
+  ansible.builtin.file:
+    path: "{{ docker_volume.json.Mountpoint }}/fullchain.pem"
+    state: file
+    mode: '0444'
+
+- name: Copy certificate as CA certificate for Nginx configuration
+  ansible.builtin.copy:
+    dest: "{{ docker_volume.json.Mountpoint }}/ca.pem"
+    force: false
+    mode: preserve
+    remote_src: true
+    src: "{{ docker_volume.json.Mountpoint }}/fullchain.pem"
+    validate: openssl x509 -in %s -text -noout

--- a/roles/vouch/files/vouch.nomad
+++ b/roles/vouch/files/vouch.nomad
@@ -1,0 +1,106 @@
+variable "region" {
+  type = string
+  description = "The region in which to run the service"
+}
+
+variable "datacenter" {
+  type = string
+  description = "The datacenter in which to run the service"
+}
+
+job "vouch" {
+  region = var.region
+
+  datacenters = [var.datacenter]
+
+  type = "service"
+
+  group "vouch" {
+    network {
+      port "http" {}
+    }
+
+    task "vouch" {
+      driver = "docker"
+
+      config {
+        image = "quay.io/vouch/vouch-proxy"
+
+        force_pull = true
+
+        network_mode = "host"
+      }
+
+      template {
+        data = <<EOH
+{{- range $key, $value := (key "vouch" | parseJSON) -}}
+{{- $key | trimSpace -}}={{- $value | toJSON }}
+{{ end -}}
+VOUCH_PORT={{ env "NOMAD_PORT_http" }}
+VOUCH_LISTEN=127.0.0.1
+EOH
+
+        destination = "/secrets/.env"
+        env = true
+      }
+
+      resources {
+        cpu = 100
+        memory = 512
+        memory_max = 2048
+      }
+
+      service {
+        name = "vouch"
+
+        port = "http"
+
+        address = "127.0.0.1"
+
+        tags = [
+          "http"
+        ]
+
+        check {
+          success_before_passing = 3
+          failures_before_critical = 2
+
+          interval = "5s"
+
+          name = "HTTP"
+          path = "/healthcheck"
+          port = "http"
+          protocol = "http"
+          timeout = "1s"
+          type = "http"
+        }
+
+        check_restart {
+          limit = 5
+          grace = "20s"
+        }
+
+        meta {
+          nginx-config = "location / {proxy_pass http://vouch;proxy_set_header Host $http_host;} location /static/ {proxy_pass http://vouch;proxy_pass_request_headers off;proxy_pass_request_body off;proxy_cache vouch_assets;proxy_cache_valid 24h;add_header X-Cache-Status $upstream_cache_status;}"
+          firewall-rules = jsonencode(["internet"])
+        }
+      }
+
+      restart {
+        attempts = 1
+        delay = "10s"
+        interval = "1m"
+        mode = "fail"
+      }
+    }
+
+    reschedule {
+      attempts  = 0
+      unlimited = false
+    }
+  }
+
+  update {
+    max_parallel = 0
+  }
+}

--- a/roles/vouch/tasks/main.yml
+++ b/roles/vouch/tasks/main.yml
@@ -1,0 +1,121 @@
+---
+#
+# Manages the vouch job within Nomad
+# https://github.com/vouch/vouch-proxy
+#
+- name: Check if Vouch configuration has been loaded in Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/kv/vouch
+    status_code:
+    - 200
+  register: vouch_config
+  ignore_errors: true
+
+- name: Check for required keys in configuration
+  ansible.builtin.fail:
+    msg: Vouch configuration has been loaded in Consul but is missing some required parameters. Check to make sure VOUCH_DOMAINS, OAUTH_PROVIDER, OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET, and OAUTH_CALLBACK_URL are all present in the map.
+  when: >-
+    vouch_config.status == 200 and (
+      ("VOUCH_DOMAINS" not in (vouch_config.json.0.Value | b64decode | from_json))
+      or ("OAUTH_PROVIDER" not in (vouch_config.json.0.Value | b64decode | from_json))
+      or ("OAUTH_CLIENT_ID" not in (vouch_config.json.0.Value | b64decode | from_json))
+      or ("OAUTH_CLIENT_SECRET" not in (vouch_config.json.0.Value | b64decode | from_json))
+      or ("OAUTH_CALLBACK_URL" not in (vouch_config.json.0.Value | b64decode | from_json))
+    )
+
+- name: Run Vouch job
+  when: vouch_config.status == 200
+  block:
+
+  - name: Generate job submission JSON
+    ansible.builtin.command:
+      argv:
+      - nomad
+      - job
+      - run
+      - -no-color
+      - -output
+      - -var
+      - region={{ region }}
+      - -var
+      - datacenter={{ datacenter }}
+      - "-"
+      stdin: "{{ lookup('ansible.builtin.file', './vouch.nomad') }}"
+    register: nomad_job_json
+    changed_when: false
+
+  - name: Submit job to Nomad
+    ansible.builtin.uri:
+      follow_redirects: none
+      force: true
+      use_netrc: false
+      use_proxy: false
+      validate_certs: false
+      return_content: true
+      headers:
+        X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+      body: "{{ nomad_job_json.stdout }}"
+      body_format: json
+      method: POST
+      url: http://127.0.0.1:4646/v1/jobs
+    register: job_register_output
+
+  - name: List allocations for evaluation
+    ansible.builtin.uri:
+      follow_redirects: none
+      force: true
+      use_netrc: false
+      use_proxy: false
+      validate_certs: false
+      return_content: true
+      headers:
+        X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+      method: GET
+      url: http://127.0.0.1:4646/v1/evaluation/{{ job_register_output.json.EvalID }}/allocations
+    register: allocations_output
+
+  - name: Wait for container to start
+    ansible.builtin.uri:
+      follow_redirects: none
+      force: true
+      use_netrc: false
+      use_proxy: false
+      validate_certs: false
+      return_content: true
+      headers:
+        X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+      method: GET
+      url: http://127.0.0.1:4646/v1/allocation/{{ allocations_output.json[0].ID }}
+    register: allocation_output
+    until: allocation_output.json.TaskStates.vouch.State == "running"
+    retries: 5
+    delay: 2
+    when: (allocations_output.json | length) > 0
+
+  - name: Wait for health check in Consul to be passing
+    ansible.builtin.uri:
+      follow_redirects: none
+      force: true
+      return_content: true
+      unix_socket: /var/opt/nomad/run/consul.sock
+      use_netrc: false
+      use_proxy: false
+      validate_certs: false
+      headers:
+        X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+      method: GET
+      url: http://localhost/v1/health/checks/vouch
+    register: service_status
+    until: service_status.json[0].Status == "passing"
+    retries: 5
+    delay: 2


### PR DESCRIPTION
- Configure Vouch
  - Requires config to be manually written to Consul at some point, but otherwise handles job startup & etc
- Configure Nginx
  - Generates Diffie-Hellman parameters
  - Generates a self-signed certificate
  - Reverse proxy configuration for Vouch, Nomad, Consul
  - Theoretically supports HTTP/3 but haven't been able to validate that
- ACME certificate issuance
  - Uses acme.sh to create an account and issue a certificate with the FQDN as the CN (with http-01 challenge) and `*.{datacenter}.robojackets.net` and `*.robojackets.org` as SANs (with dns-01 challenge)
- Cleans up "stuck" jobs - service jobs registered with Nomad that are not healthy in Consul