### PR TITLE
Set up more Nomad jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 inventory.yml
+credentials/

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ ungrouped:
       - 130.207.244.251
       - 130.207.244.244
       - 128.61.244.254
+      meilisearch_versions:
+      - 1.1
+      - 1.2
+      - 1.3
 ```
 
 Run the playbook like so:

--- a/playbook.yml
+++ b/playbook.yml
@@ -13,5 +13,15 @@
   - firewall-rules
   - vouch
   - nginx
+  # Roles prior to this point are required for baseline functions
+  # If you are running this on a system that is not directly accessible from the internet,
+  # comment out acme-issuance and the second nginx invocation below.
   - acme-issuance
   - nginx
+  # Roles below this point are application-specific; mix and match as needed
+  - registry
+  - redis
+  - mysql
+  - meilisearch
+  - tika
+  - batch-jobs

--- a/roles/acme-issuance/files/acme-renew.nomad
+++ b/roles/acme-issuance/files/acme-renew.nomad
@@ -1,0 +1,72 @@
+variable "region" {
+  type = string
+  description = "The region in which to run the service"
+}
+
+variable "datacenter" {
+  type = string
+  description = "The datacenter in which to run the service"
+}
+
+variable "acme-server" {
+  type = string
+  description = "The ACME service to use when renewing certificates"
+}
+
+job "acme-renew" {
+  region = var.region
+
+  datacenters = [var.datacenter]
+
+  type = "batch"
+
+  periodic {
+    cron = "0 8 * * *"
+    prohibit_overlap = true
+  }
+
+  group "acme-sh" {
+    task "acme-sh" {
+      config {
+        image = "neilpang/acme.sh"
+        args = [
+          "--cron",
+        ]
+
+        force_pull = true
+
+        network_mode = "host"
+
+        mount {
+          type = "volume"
+          target = "/acme.sh/"
+          source = "acme-account-${var.acme-server}"
+          readonly = false
+
+          volume_options {
+            no_copy = true
+          }
+        }
+
+        mount {
+          type = "volume"
+          target = "/certificate/"
+          source = "acme-certificate-${var.acme-server}"
+          readonly = false
+
+          volume_options {
+            no_copy = true
+          }
+        }
+      }
+
+      driver = "docker"
+
+      resources {
+        cpu = 1000
+        memory = 512
+        memory_max = 2048
+      }
+    }
+  }
+}

--- a/roles/acme-issuance/tasks/main.yml
+++ b/roles/acme-issuance/tasks/main.yml
@@ -144,3 +144,109 @@
       - /certificate/fullchain.pem
       - --ocsp-must-staple
       - --ecc
+
+- name: Check if a volume is created for {{ acme_server }}
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    unix_socket: /var/run/docker.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    method: GET
+    return_content: true
+    url: http://localhost/v1.43/volumes/acme-certificate-{{ acme_server }}
+    status_code:
+    - 200
+    - 404
+  register: acme_certificate_volume
+  when: not (acme_challenge_test is failed)
+
+- name: Check if a certificate was already issued from {{ acme_server }}
+  ansible.builtin.stat:
+    path: "{{ acme_certificate_volume.json.Mountpoint }}/fullchain.pem"
+  when: acme_certificate_volume.status == 200 and not (acme_challenge_test is failed)
+  register: server_cert
+
+- name: Manage renewal job
+  when: acme_certificate_volume.status == 200 and server_cert.stat.exists
+  block:
+
+  - name: Generate renewal job JSON
+    ansible.builtin.command:
+      argv:
+      - nomad
+      - job
+      - run
+      - -no-color
+      - -output
+      - -var
+      - region={{ region }}
+      - -var
+      - datacenter={{ datacenter }}
+      - -var
+      - acme-server={{ acme_server }}
+      - "-"
+      stdin: "{{ lookup('ansible.builtin.file', './acme-renew.nomad') }}"
+    register: nomad_job_json
+    changed_when: false
+
+  - name: Submit renewal job to Nomad
+    ansible.builtin.uri:
+      follow_redirects: none
+      force: true
+      use_netrc: false
+      use_proxy: false
+      validate_certs: false
+      return_content: true
+      headers:
+        X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+      body: "{{ nomad_job_json.stdout }}"
+      body_format: json
+      method: POST
+      url: http://127.0.0.1:4646/v1/jobs
+
+  - name: Force launch the job
+    ansible.builtin.uri:
+      follow_redirects: none
+      force: true
+      use_netrc: false
+      use_proxy: false
+      validate_certs: false
+      return_content: true
+      headers:
+        X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+      method: POST
+      url: http://127.0.0.1:4646/v1/job/acme-renew/periodic/force
+    register: force_launch_output
+
+  - name: List allocations for evaluation
+    ansible.builtin.uri:
+      follow_redirects: none
+      force: true
+      use_netrc: false
+      use_proxy: false
+      validate_certs: false
+      return_content: true
+      headers:
+        X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+      method: GET
+      url: http://127.0.0.1:4646/v1/evaluation/{{ force_launch_output.json.EvalID }}/allocations
+    register: evaluation_output
+
+  - name: Wait for allocation to complete
+    ansible.builtin.uri:
+      follow_redirects: none
+      force: true
+      use_netrc: false
+      use_proxy: false
+      validate_certs: false
+      return_content: true
+      headers:
+        X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+      method: GET
+      url: http://127.0.0.1:4646/v1/allocation/{{ evaluation_output.json[0].ID }}
+    register: allocation_output
+    until: allocation_output.json.ClientStatus == "complete"
+    retries: 5
+    delay: 2

--- a/roles/batch-jobs/files/docker-system-prune.nomad
+++ b/roles/batch-jobs/files/docker-system-prune.nomad
@@ -1,0 +1,39 @@
+variable "region" {
+  type = string
+  description = "The region in which to run the service"
+}
+
+variable "datacenter" {
+  type = string
+  description = "The datacenter in which to run the service"
+}
+
+job "docker-system-prune" {
+  region = var.region
+
+  datacenters = [var.datacenter]
+
+  type = "batch"
+
+  periodic {
+    cron = "0 9 * * *"
+    prohibit_overlap = true
+  }
+
+  group "docker-system-prune" {
+    task "docker-system-prune" {
+      driver = "raw_exec"
+
+      config {
+        command = "/bin/docker"
+        args    = [
+          "system",
+          "prune",
+          "--all",
+          "--volumes",
+          "--force",
+        ]
+      }
+    }
+  }
+}

--- a/roles/batch-jobs/files/unmount-nethomes.nomad
+++ b/roles/batch-jobs/files/unmount-nethomes.nomad
@@ -1,0 +1,47 @@
+variable "region" {
+  type = string
+  description = "The region in which to run the service"
+}
+
+variable "datacenter" {
+  type = string
+  description = "The datacenter in which to run the service"
+}
+
+job "unmount-nethomes" {
+  region = var.region
+
+  datacenters = [var.datacenter]
+
+  type = "batch"
+
+  periodic {
+    cron = "@hourly"
+    prohibit_overlap = true
+  }
+
+  group "unmount-nethomes" {
+    task "unmount-nethomes" {
+      driver = "raw_exec"
+
+      config {
+        command = "/bin/bash"
+        args    = [
+          "-euxo",
+          "pipefail",
+          "-c",
+<<EOH
+for user in $(mount | grep /nethome/ | cut --delimiter=/ --fields=7 | cut --delimiter=" " --fields=1); do
+    if ! [[ $(who | grep $user) ]]; then
+        if ! [[ $user == operator ]]; then
+          echo "Unmounting nethome for $user"
+          umount /nethome/$user
+        fi
+    fi
+done
+EOH
+        ]
+      }
+    }
+  }
+}

--- a/roles/batch-jobs/tasks/main.yml
+++ b/roles/batch-jobs/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+#
+# Deploys various maintenance batch jobs that don't fit anywhere else
+#
+- name: Loop over jobs
+  include_tasks: run-single-job.yml
+  loop: "{{ query('ansible.builtin.fileglob', '*.nomad') }}"

--- a/roles/batch-jobs/tasks/run-single-job.yml
+++ b/roles/batch-jobs/tasks/run-single-job.yml
@@ -1,0 +1,80 @@
+---
+#
+# Run a single batch job, for use in a loop
+#
+- name: Generate job JSON - {{ item | basename }}
+  ansible.builtin.command:
+    argv:
+    - nomad
+    - job
+    - run
+    - -no-color
+    - -output
+    - -var
+    - region={{ region }}
+    - -var
+    - datacenter={{ datacenter }}
+    - "-"
+    stdin: "{{ lookup('ansible.builtin.file', item) }}"
+  register: nomad_job_json
+  changed_when: false
+
+- name: Submit job to Nomad - {{ item | basename }}
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    body: "{{ nomad_job_json.stdout }}"
+    body_format: json
+    method: POST
+    url: http://127.0.0.1:4646/v1/jobs
+
+- name: Force launch the job - {{ item | basename }}
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: POST
+    url: http://127.0.0.1:4646/v1/job/{{ (nomad_job_json.stdout | from_json).Job.ID }}/periodic/force
+  register: force_launch_output
+
+- name: List allocations for evaluation - {{ item | basename }}
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: GET
+    url: http://127.0.0.1:4646/v1/evaluation/{{ force_launch_output.json.EvalID }}/allocations
+  register: evaluation_output
+
+- name: Wait for allocation to complete - {{ item | basename }}
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: GET
+    url: http://127.0.0.1:4646/v1/allocation/{{ evaluation_output.json[0].ID }}
+  register: allocation_output
+  until: allocation_output.json.ClientStatus == "complete"
+  retries: 5
+  delay: 2

--- a/roles/meilisearch/files/meilisearch.nomad
+++ b/roles/meilisearch/files/meilisearch.nomad
@@ -1,0 +1,127 @@
+variable "region" {
+  type = string
+  description = "The region in which to run the service"
+}
+
+variable "datacenter" {
+  type = string
+  description = "The datacenter in which to run the service"
+}
+
+variable "version" {
+  type = string
+  description = "The version of Meilisearch to run"
+}
+
+job "meilisearch" {
+  region = var.region
+
+  datacenters = [var.datacenter]
+
+  type = "service"
+
+  group "meilisearch" {
+    network {
+      port "http" {}
+    }
+
+    task "meilisearch" {
+      driver = "docker"
+
+      config {
+        image = "getmeili/meilisearch:v${var.version}"
+
+        args = [
+          "/bin/meilisearch",
+          "--db-path",
+          "/meilisearch_data/",
+          "--http-addr",
+          "127.0.0.1:${NOMAD_PORT_http}",
+          "--env",
+          "production",
+          "--max-indexing-memory",
+          "4Gb",
+          "--http-payload-size-limit",
+          "100Mb",
+        ]
+
+        force_pull = true
+
+        network_mode = "host"
+
+        mount {
+          type = "volume"
+          target = "/meilisearch_data/"
+          source = "${NOMAD_JOB_NAME}"
+          readonly = false
+
+          volume_options {
+            no_copy = true
+          }
+        }
+      }
+
+      resources {
+        cpu = 100
+        memory = 256
+        memory_max = 8096
+      }
+
+      template {
+        data = <<EOF
+MEILI_MASTER_KEY="{{- key "meilisearch/master-key" | trimSpace -}}"
+EOF
+
+        destination = "/secrets/.env"
+        env = true
+      }
+
+      service {
+        name = "${NOMAD_JOB_NAME}"
+
+        port = "http"
+
+        address = "127.0.0.1"
+
+        tags = [
+          "http"
+        ]
+
+        check {
+          success_before_passing = 3
+          failures_before_critical = 2
+
+          interval = "5s"
+
+          name = "HTTP"
+          path = "/health"
+          port = "http"
+          protocol = "http"
+          timeout = "1s"
+          type = "http"
+        }
+
+        check_restart {
+          limit = 5
+          grace = "20s"
+        }
+      }
+
+      restart {
+        attempts = 1
+        delay = "10s"
+        interval = "1m"
+        mode = "fail"
+      }
+    }
+
+    reschedule {
+      attempts  = 0
+      unlimited = false
+    }
+  }
+
+  update {
+    max_parallel = 0
+  }
+}

--- a/roles/meilisearch/tasks/deploy-single-version.yml
+++ b/roles/meilisearch/tasks/deploy-single-version.yml
@@ -1,0 +1,159 @@
+---
+#
+# Deploys a single version of Meilisearch, for use in a loop
+#
+- name: Generate v{{ meilisearch_version }} job submission JSON
+  ansible.builtin.command:
+    argv:
+    - nomad
+    - job
+    - run
+    - -no-color
+    - -output
+    - -var
+    - region={{ region }}
+    - -var
+    - datacenter={{ datacenter }}
+    - -var
+    - version={{ meilisearch_version }}
+    - "-"
+    stdin: "{{ lookup('ansible.builtin.file', './meilisearch.nomad') }}"
+  register: nomad_job_json
+  changed_when: false
+
+- name: Submit v{{ meilisearch_version }} job to Nomad
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    body: "{{ nomad_job_json.stdout | from_json | combine({'Job': {'ID': 'meilisearch-v' + meilisearch_version|string|replace('.','-'), 'Name': 'meilisearch-v' + meilisearch_version|string|replace('.','-')}}, recursive=true) }}"
+    body_format: json
+    method: POST
+    url: http://127.0.0.1:4646/v1/jobs
+  register: job_register_output
+
+- name: List allocations for evaluation for v{{ meilisearch_version }}
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: GET
+    url: http://127.0.0.1:4646/v1/evaluation/{{ job_register_output.json.EvalID }}/allocations
+  register: allocations_output
+
+- name: Wait for container to start for v{{ meilisearch_version }}
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: GET
+    url: http://127.0.0.1:4646/v1/allocation/{{ allocations_output.json[0].ID }}
+  register: allocation_output
+  until: allocation_output.json.TaskStates.meilisearch.State == "running"
+  retries: 5
+  delay: 2
+  when: (allocations_output.json | length) > 0
+
+- name: Wait for health checks in Consul to be passing for v{{ meilisearch_version }}
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/health/checks/meilisearch-v{{ meilisearch_version|replace('.','-') }}
+  register: service_status
+  until: service_status.json[0].Status == "passing"
+  retries: 5
+  delay: 2
+
+- name: Check if admin key for v{{ meilisearch_version }} has been loaded in Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/kv/meilisearch/admin-key-v{{ meilisearch_version }}
+    status_code:
+    - 200
+    - 404
+  register: meilisearch_master_key
+
+- name: Store admin key in Consul
+  when: meilisearch_master_key.status == 404
+  block:
+
+  - name: Get service information from Consul
+    ansible.builtin.uri:
+      follow_redirects: none
+      force: true
+      return_content: true
+      unix_socket: /var/opt/nomad/run/consul.sock
+      use_netrc: false
+      use_proxy: false
+      validate_certs: false
+      headers:
+        X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+      method: GET
+      url: http://localhost/v1/catalog/service/meilisearch-v{{ meilisearch_version|replace('.','-') }}
+    register: meilisearch_service
+
+  - name: Retrieve keys from v{{ meilisearch_version }}
+    ansible.builtin.uri:
+      follow_redirects: none
+      force: true
+      return_content: true
+      use_netrc: false
+      use_proxy: false
+      validate_certs: false
+      headers:
+        Authorization: "Bearer {{ ansible_facts['meilisearch_master_key'] }}"
+      method: GET
+      url: http://127.0.0.1:{{ meilisearch_service.json.0.ServicePort }}/keys
+    register: meilisearch_keys
+
+  - name: Loop over keys from v{{ meilisearch_version }}
+    include_tasks: store-admin-key.yml
+    loop: "{{ meilisearch_keys.json.results }}"
+    loop_control:
+      loop_var: meilisearch_key
+
+- name: Check if admin key for v{{ meilisearch_version }} has been loaded in Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/kv/meilisearch/admin-key-v{{ meilisearch_version }}

--- a/roles/meilisearch/tasks/main.yml
+++ b/roles/meilisearch/tasks/main.yml
@@ -1,0 +1,66 @@
+---
+#
+# Deploy Meilisearch, used for search for Laravel apps
+# Multiple versions can be deployed independently to allow for seamless-ish updates
+# https://www.meilisearch.com/
+#
+- name: Check if a master key has been loaded in Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/kv/meilisearch/master-key
+    status_code:
+    - 200
+    - 404
+  register: meilisearch_master_key
+
+- name: Store master key in Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    body: "{{ lookup('ansible.builtin.password', 'credentials/meilisearch-master-key', chars=['ascii_letters', 'digits'], length=128) }}"
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: PUT
+    url: http://localhost/v1/kv/meilisearch/master-key
+  changed_when: true
+  when: meilisearch_master_key.status == 404
+
+- name: Read master key from Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/kv/meilisearch/master-key
+  register: meilisearch_master_key
+
+- name: Set master key as fact
+  ansible.builtin.set_fact:
+    meilisearch_master_key: "{{ meilisearch_master_key.json.0.Value | b64decode }}"
+    cacheable: yes
+
+- name: Loop over versions
+  include_tasks: deploy-single-version.yml
+  loop: "{{ meilisearch_versions }}"
+  loop_control:
+    loop_var: meilisearch_version

--- a/roles/meilisearch/tasks/store-admin-key.yml
+++ b/roles/meilisearch/tasks/store-admin-key.yml
@@ -1,0 +1,21 @@
+---
+#
+# Stores the default admin key for a given Meilisearch version in Consul
+# This is a little wonky because I didn't want to require installing JMESPath which is the probably-simpler way to do this
+#
+- name: Store admin key in Consul for v{{ meilisearch_version }}
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    body: "{{ meilisearch_key.key }}"
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: PUT
+    url: http://localhost/v1/kv/meilisearch/admin-key-v{{ meilisearch_version }}
+  changed_when: true
+  when: meilisearch_key.name == "Default Admin API Key"

--- a/roles/mysql/files/mysql.nomad
+++ b/roles/mysql/files/mysql.nomad
@@ -1,0 +1,121 @@
+variable "region" {
+  type = string
+  description = "The region in which to run the service"
+}
+
+variable "datacenter" {
+  type = string
+  description = "The datacenter in which to run the service"
+}
+
+job "mysql" {
+  region = var.region
+
+  datacenters = [var.datacenter]
+
+  type = "service"
+
+  group "mysql" {
+    volume "run" {
+      type = "host"
+      source = "run"
+    }
+
+    network {
+      port "mysql" {
+        static = 3306
+      }
+    }
+
+    task "mysql" {
+      driver = "docker"
+
+      config {
+        image = "mysql"
+
+        args = [
+          "--socket=/var/opt/nomad/run/${NOMAD_JOB_NAME}-${NOMAD_ALLOC_ID}.sock"
+        ]
+
+        force_pull = true
+
+        network_mode = "host"
+
+        cap_add = ["sys_nice"]
+
+        mount {
+          type = "volume"
+          target = "/var/lib/mysql/"
+          source = "mysql"
+          readonly = false
+
+          volume_options {
+            no_copy = true
+          }
+        }
+      }
+
+      template {
+        data = <<EOH
+MYSQL_ROOT_PASSWORD={{- key "mysql/root_password" -}}
+EOH
+
+        destination = "/secrets/.env"
+        env = true
+      }
+
+      resources {
+        cpu = 100
+        memory = 1024
+        memory_max = 2048
+      }
+
+      volume_mount {
+        volume = "run"
+        destination = "/var/opt/nomad/run"
+      }
+
+      service {
+        name = "mysql"
+
+        port = "mysql"
+
+        address = "127.0.0.1"
+
+        tags = [
+          "mysql"
+        ]
+
+        check {
+          success_before_passing = 3
+          failures_before_critical = 2
+
+          interval = "5s"
+
+          name = "TCP"
+          port = "mysql"
+          timeout = "1s"
+          type = "tcp"
+        }
+
+        check_restart {
+          limit = 5
+          grace = "20s"
+        }
+
+        meta {
+          socket = "/var/opt/nomad/run/${NOMAD_JOB_NAME}-${NOMAD_ALLOC_ID}.sock"
+        }
+      }
+    }
+
+    reschedule {
+      attempts  = 0
+      unlimited = false
+    }
+  }
+
+  update {
+    max_parallel = 0
+  }
+}

--- a/roles/mysql/tasks/main.yml
+++ b/roles/mysql/tasks/main.yml
@@ -1,0 +1,128 @@
+---
+#
+# Run a MySQL database server
+# Used as a primary database by several applications
+# https://www.mysql.com/
+#
+- name: Check if password has been loaded in Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/kv/mysql/root_password
+    status_code:
+    - 200
+    - 404
+  register: mysql_password
+
+- name: Generate and store password in Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    body: "{{ lookup('ansible.builtin.password', '/dev/null', chars=['ascii_letters', 'digits'], length=128) }}"
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: PUT
+    url: http://localhost/v1/kv/mysql/root_password
+  changed_when: true
+  when: mysql_password.status == 404
+
+- name: Generate job submission JSON
+  ansible.builtin.command:
+    argv:
+    - nomad
+    - job
+    - run
+    - -no-color
+    - -output
+    - -var
+    - region={{ region }}
+    - -var
+    - datacenter={{ datacenter }}
+    - "-"
+    stdin: "{{ lookup('ansible.builtin.file', './mysql.nomad') }}"
+  register: nomad_job_json
+  changed_when: false
+
+- name: Submit job to Nomad
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    body: "{{ nomad_job_json.stdout }}"
+    body_format: json
+    method: POST
+    url: http://127.0.0.1:4646/v1/jobs
+  register: job_register_output
+
+- name: List allocations for evaluation
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: GET
+    url: http://127.0.0.1:4646/v1/evaluation/{{ job_register_output.json.EvalID }}/allocations
+  register: allocations_output
+
+- name: Wait for container to start
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: GET
+    url: http://127.0.0.1:4646/v1/allocation/{{ allocations_output.json[0].ID }}
+  register: allocation_output
+  until: allocation_output.json.TaskStates.mysql.State == "running"
+  retries: 5
+  delay: 2
+  when: (allocations_output.json | length) > 0
+
+- name: Wait for port 3306 to be listening
+  ansible.builtin.wait_for:
+    port: 3306
+    timeout: 30
+
+- name: Wait for health checks in Consul to be passing
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/health/checks/mysql
+  register: service_status
+  until: service_status.json[0].Status == "passing"
+  retries: 5
+  delay: 2

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -401,3 +401,39 @@
   until: service_status.json[0].Status == "passing" and service_status.json[1].Status == "passing"
   retries: 5
   delay: 2
+
+- name: Ping Nomad from controller to grant access to control plane web UIs
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    method: GET
+    return_content: true
+    url: https://{{ ansible_host }}/v1/acl/token/self
+    headers:
+      Host: nomad.{{ datacenter }}.robojackets.net
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    status_code:
+    - 200
+    timeout: 5
+  delegate_to: 127.0.0.1
+
+- name: Ping Consul from controller to grant access to control plane web UIs
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    method: GET
+    return_content: true
+    url: https://{{ ansible_host }}/v1/acl/token/self
+    headers:
+      Host: consul.{{ datacenter }}.robojackets.net
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    status_code:
+    - 200
+    timeout: 5
+  delegate_to: 127.0.0.1

--- a/roles/nginx/templates/00-baseline.conf
+++ b/roles/nginx/templates/00-baseline.conf
@@ -16,4 +16,4 @@ proxy_http_version 1.1;
 proxy_cache_revalidate on;
 
 proxy_cache_path /var/cache/nginx/vouch_assets/ use_temp_path=off keys_zone=vouch_assets:1m inactive=24h;
-proxy_cache_path /var/cache/nginx/vouch_auth/ use_temp_path=off keys_zone=vouch_auth:1m inactive=24h;
+proxy_cache_path /var/cache/nginx/control_plane_auth/ use_temp_path=off keys_zone=control_plane_auth:1m inactive=24h;

--- a/roles/nginx/templates/01-default-http.conf
+++ b/roles/nginx/templates/01-default-http.conf
@@ -21,6 +21,12 @@ server {
     return 200 "{{ lookup('ansible.builtin.template', './index.html') | replace('"', '\\"') }}";
   }
 
+  location = /robots.txt {
+    default_type text/plain;
+    return 200 "User-agent: *\nDisallow: /";
+    allow all;
+  }
+
   location / {
     return 404;
   }

--- a/roles/nginx/templates/02-default-https.conf
+++ b/roles/nginx/templates/02-default-https.conf
@@ -48,6 +48,12 @@ server {
     return 200 "{{ lookup('ansible.builtin.template', './index.html') | replace('"', '\\"') }}";
   }
 
+  location = /robots.txt {
+    default_type text/plain;
+    return 200 "User-agent: *\nDisallow: /";
+    allow all;
+  }
+
   location / {
     return 404;
   }

--- a/roles/nginx/templates/03-consul.conf
+++ b/roles/nginx/templates/03-consul.conf
@@ -1,7 +1,6 @@
 {{ ansible_managed | comment }}
 
 proxy_cache_path /var/cache/nginx/consul_assets/ use_temp_path=off keys_zone=consul_assets:1m inactive=24h;
-proxy_cache_path /var/cache/nginx/consul_token_auth/ use_temp_path=off keys_zone=consul_token_auth:1m inactive=24h;
 
 upstream consul {
     server unix:/var/opt/nomad/run/consul.sock;
@@ -28,6 +27,14 @@ server {
   http3 on;
   http3_hq on;
 
+  {# static assets #}
+
+  location = /robots.txt {
+    default_type text/plain;
+    return 200 "User-agent: *\nDisallow: /";
+    allow all;
+  }
+
   location /ui/assets/ {
     proxy_pass http://consul;
     proxy_pass_request_headers off;
@@ -40,14 +47,20 @@ server {
     allow all;
   }
 
+  {# web ui #}
+
   location / {
     proxy_pass http://consul;
     proxy_read_timeout 360s;
     proxy_set_header Connection "";
   }
 
-  location = /v1/acl/token/self {
-    proxy_pass http://consul;
+  {# api auth #}
+
+  location = /consul-token-validate {
+    internal;
+
+    proxy_pass http://consul/v1/acl/token/self;
     proxy_pass_request_headers off;
     proxy_pass_request_body off;
 
@@ -55,39 +68,26 @@ server {
 
     proxy_set_header X-Consul-Token $http_x_consul_token;
 
-    proxy_cache_valid 200 24h;
-    proxy_cache consul_token_auth;
+    proxy_cache_valid 200 48h;
+    proxy_cache control_plane_auth;
     proxy_cache_methods GET;
-    proxy_cache_key $http_x_consul_token;
+    proxy_cache_key $remote_addr;
+    proxy_ignore_headers Vary;
   }
+
+  {# api endpoints #}
 
   location /v1/ {
     proxy_pass http://consul;
     proxy_read_timeout 360s;
     proxy_set_header Connection "";
 
-    auth_request /v1/acl/token/self;
-  }
-
-{% if vouch_service_status.status == 200 and (vouch_service_status.json | length) > 0 and vouch_service_status.json[0].Status == "passing" %}
-
-  location = /v1/internal/acl/authorize {
-    proxy_pass http://consul;
-    proxy_read_timeout 360s;
-    proxy_set_header Connection "";
-
-    auth_request /validate;
-  }
-
-  location = /v1/catalog/datacenters {
-    proxy_pass http://consul;
-    proxy_read_timeout 360s;
-    proxy_set_header Connection "";
-
-    auth_request /validate;
+    auth_request /consul-token-validate;
   }
 
   satisfy any;
+
+{% if vouch_service_status.status == 200 and (vouch_service_status.json | length) > 0 and vouch_service_status.json[0].Status == "passing" %}
 
   auth_request /validate;
 
@@ -97,14 +97,16 @@ server {
     proxy_pass http://vouch;
 
     proxy_set_header Host $http_host;
+    proxy_set_header Cookie $http_cookie;
 
+    proxy_pass_request_headers off;
     proxy_pass_request_body off;
-    proxy_set_header Content-Length "";
 
-    proxy_cache_valid 200 1h;
-    proxy_cache vouch_auth;
+    proxy_cache_valid 200 48h;
+    proxy_cache control_plane_auth;
     proxy_cache_methods GET;
-    proxy_cache_key $cookie_vouchcookie;
+    proxy_cache_key $remote_addr;
+    proxy_ignore_headers Vary;
 
     auth_request_set $auth_resp_jwt $upstream_http_x_vouch_jwt;
     auth_request_set $auth_resp_err $upstream_http_x_vouch_err;
@@ -116,6 +118,12 @@ server {
   location @error401 {
     return 302 https://vouch.{{ datacenter }}.robojackets.net/login?url=https://consul.{{ datacenter }}.robojackets.net$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
   }
+
+{% else %}
+
+  {# still using auth_request here so IP addresses demonstrating possession of a valid Consul token can use all routes #}
+
+  auth_request /consul-token-validate;
 
 {% endif %}
 

--- a/roles/nginx/templates/04-nomad.conf
+++ b/roles/nginx/templates/04-nomad.conf
@@ -1,7 +1,6 @@
 {{ ansible_managed | comment }}
 
 proxy_cache_path /var/cache/nginx/nomad_assets/ use_temp_path=off keys_zone=nomad_assets:1m inactive=24h;
-proxy_cache_path /var/cache/nginx/nomad_token_auth/ use_temp_path=off keys_zone=nomad_token_auth:1m inactive=24h;
 
 server {
   server_name nomad.{{ datacenter }}.robojackets.net;
@@ -15,53 +14,12 @@ server {
   http3 on;
   http3_hq on;
 
-  location / {
-    proxy_pass http://nomad;
-    proxy_read_timeout 360s;
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection 'upgrade';
-    proxy_buffering off;
-    proxy_set_header Origin "${scheme}://${proxy_host}";
-  }
+  {# static assets #}
 
-  location /v1/acl/auth-methods {
-    proxy_pass http://nomad;
-    proxy_read_timeout 360s;
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection 'upgrade';
-    proxy_buffering off;
-    proxy_set_header Origin "${scheme}://${proxy_host}";
-
+  location = /robots.txt {
+    default_type text/plain;
+    return 200 "User-agent: *\nDisallow: /";
     allow all;
-  }
-
-  location = /v1/acl/token/self {
-    proxy_pass http://nomad;
-    proxy_pass_request_headers off;
-    proxy_pass_request_body off;
-
-    proxy_read_timeout 5s;
-
-    proxy_set_header X-Nomad-Token $http_x_nomad_token;
-
-    proxy_cache_valid 200 24h;
-    proxy_cache nomad_token_auth;
-    proxy_cache_methods GET;
-    proxy_cache_key $http_x_nomad_token;
-
-    proxy_intercept_errors on;
-
-    error_page 500 =403 /error/403;
-  }
-
-  location /v1/ {
-    proxy_pass http://nomad;
-    proxy_read_timeout 360s;
-    proxy_set_header Connection "";
-
-    auth_request /v1/acl/token/self;
   }
 
   location /ui/assets/ {
@@ -100,6 +58,65 @@ server {
     allow all;
   }
 
+  {# web ui #}
+
+  location / {
+    proxy_pass http://nomad;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_buffering off;
+    proxy_set_header Origin "${scheme}://${proxy_host}";
+  }
+
+  {# auth-methods always needs to be visible so nomad login works nicely #}
+
+  location /v1/acl/auth-methods {
+    proxy_pass http://nomad;
+    proxy_read_timeout 360s;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_buffering off;
+    proxy_set_header Origin "${scheme}://${proxy_host}";
+
+    allow all;
+  }
+
+  {# api auth #}
+
+  location = /nomad-token-validate {
+    internal;
+    proxy_pass http://nomad/v1/acl/token/self;
+    proxy_pass_request_headers off;
+    proxy_pass_request_body off;
+
+    proxy_read_timeout 5s;
+
+    proxy_set_header X-Nomad-Token $http_x_nomad_token;
+
+    proxy_cache_valid 200 48h;
+    proxy_cache control_plane_auth;
+    proxy_cache_methods GET;
+    proxy_cache_key $remote_addr;
+    proxy_ignore_headers Vary;
+
+    proxy_intercept_errors on;
+
+    error_page 500 =403 /error/403;
+  }
+
+  {# api endpoints #}
+
+  location /v1/ {
+    proxy_pass http://nomad;
+    proxy_read_timeout 360s;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_buffering off;
+    proxy_set_header Origin "${scheme}://${proxy_host}";
+
+    auth_request /nomad-token-validate;
+  }
+
   location = /error/403 {
     internal;
     return 403;
@@ -110,9 +127,9 @@ server {
   add_header X-Content-Type-Options nosniff always;
   add_header Referrer-Policy no-referrer always;
 
-{% if vouch_service_status.status == 200 and (vouch_service_status.json | length) > 0 and vouch_service_status.json[0].Status == "passing" %}
-
   satisfy any;
+
+{% if vouch_service_status.status == 200 and (vouch_service_status.json | length) > 0 and vouch_service_status.json[0].Status == "passing" %}
 
   auth_request /validate;
 
@@ -124,10 +141,11 @@ server {
     proxy_pass_request_body off;
     proxy_set_header Content-Length "";
 
-    proxy_cache_valid 200 1h;
-    proxy_cache vouch_auth;
+    proxy_cache_valid 200 48h;
+    proxy_cache control_plane_auth;
     proxy_cache_methods GET;
-    proxy_cache_key $cookie_vouchcookie;
+    proxy_cache_key $remote_addr;
+    proxy_ignore_headers Vary;
 
     auth_request_set $auth_resp_jwt $upstream_http_x_vouch_jwt;
     auth_request_set $auth_resp_err $upstream_http_x_vouch_err;
@@ -139,6 +157,12 @@ server {
   location @error401 {
     return 302 https://vouch.{{ datacenter }}.robojackets.net/login?url=https://nomad.{{ datacenter }}.robojackets.net$request_uri&vouch-failcount=$auth_resp_failcount&X-Vouch-Token=$auth_resp_jwt&error=$auth_resp_err;
   }
+
+{% else %}
+
+  {# still using auth_request here so IP addresses demonstrating possession of a valid Nomad token can use all routes #}
+
+  auth_request /nomad-token-validate;
 
 {% endif %}
 

--- a/roles/redis/files/redis.nomad
+++ b/roles/redis/files/redis.nomad
@@ -1,0 +1,122 @@
+variable "region" {
+  type = string
+  description = "The region in which to run the service"
+}
+
+variable "datacenter" {
+  type = string
+  description = "The datacenter in which to run the service"
+}
+
+job "redis" {
+  region = var.region
+
+  datacenters = [var.datacenter]
+
+  type = "service"
+
+  group "redis" {
+    volume "run" {
+      type = "host"
+      source = "run"
+    }
+
+    network {
+      port "resp" {}
+    }
+
+    task "redis" {
+      driver = "docker"
+
+      config {
+        image = "redis"
+
+        args = [
+          "/usr/local/etc/redis/redis.conf"
+        ]
+
+        force_pull = true
+
+        network_mode = "host"
+
+        mount {
+          type   = "bind"
+          source = "secrets/"
+          target = "/usr/local/etc/redis/"
+        }
+      }
+
+      resources {
+        cpu = 100
+        memory = 512
+        memory_max = 2048
+      }
+
+      volume_mount {
+        volume = "run"
+        destination = "/var/opt/nomad/run/"
+      }
+
+      template {
+        data = <<EOH
+bind 0.0.0.0
+port {{ env "NOMAD_PORT_resp" }}
+unixsocket /var/opt/nomad/run/{{ env "NOMAD_JOB_NAME" }}-{{ env "NOMAD_ALLOC_ID" }}.sock
+unixsocketperm 777
+requirepass {{ key "redis/password" }}
+maxmemory {{ env "NOMAD_MEMORY_LIMIT" }}mb
+maxmemory-policy allkeys-lru
+EOH
+
+        destination = "secrets/redis.conf"
+      }
+
+      service {
+        name = "redis"
+
+        port = "resp"
+
+        tags = [
+          "resp"
+        ]
+
+        check {
+          success_before_passing = 3
+          failures_before_critical = 2
+
+          interval = "5s"
+
+          name = "TCP"
+          port = "resp"
+          timeout = "1s"
+          type = "tcp"
+        }
+
+        check_restart {
+          limit = 5
+          grace = "20s"
+        }
+
+        meta {
+          socket = "/var/opt/nomad/run/${NOMAD_JOB_NAME}-${NOMAD_ALLOC_ID}.sock"
+        }
+      }
+
+      restart {
+        attempts = 1
+        delay = "10s"
+        interval = "1m"
+        mode = "fail"
+      }
+    }
+
+    reschedule {
+      attempts  = 0
+      unlimited = false
+    }
+  }
+
+  update {
+    max_parallel = 0
+  }
+}

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -1,0 +1,123 @@
+---
+#
+# Run a Redis server
+# Used as a cache by several applications
+# https://redis.io/
+#
+- name: Check if password has been loaded in Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/kv/redis/password
+    status_code:
+    - 200
+    - 404
+  register: redis_password
+
+- name: Generate and store password in Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    body: "{{ lookup('ansible.builtin.password', '/dev/null', chars=['ascii_letters', 'digits'], length=128) }}"
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: PUT
+    url: http://localhost/v1/kv/redis/password
+  changed_when: true
+  when: redis_password.status == 404
+
+- name: Generate job submission JSON
+  ansible.builtin.command:
+    argv:
+    - nomad
+    - job
+    - run
+    - -no-color
+    - -output
+    - -var
+    - region={{ region }}
+    - -var
+    - datacenter={{ datacenter }}
+    - "-"
+    stdin: "{{ lookup('ansible.builtin.file', './redis.nomad') }}"
+  register: nomad_job_json
+  changed_when: false
+
+- name: Submit job to Nomad
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    body: "{{ nomad_job_json.stdout }}"
+    body_format: json
+    method: POST
+    url: http://127.0.0.1:4646/v1/jobs
+  register: job_register_output
+
+- name: List allocations for evaluation
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: GET
+    url: http://127.0.0.1:4646/v1/evaluation/{{ job_register_output.json.EvalID }}/allocations
+  register: allocations_output
+
+- name: Wait for container to start
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: GET
+    url: http://127.0.0.1:4646/v1/allocation/{{ allocations_output.json[0].ID }}
+  register: allocation_output
+  until: allocation_output.json.TaskStates.redis.State == "running"
+  retries: 5
+  delay: 2
+  when: (allocations_output.json | length) > 0
+
+- name: Wait for health checks in Consul to be passing
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/health/checks/redis
+  register: service_status
+  until: service_status.json[0].Status == "passing"
+  retries: 5
+  delay: 2

--- a/roles/registry/files/registry-garbage-collection.nomad
+++ b/roles/registry/files/registry-garbage-collection.nomad
@@ -1,0 +1,81 @@
+variable "region" {
+  type = string
+  description = "The region in which to run the service"
+}
+
+variable "datacenter" {
+  type = string
+  description = "The datacenter in which to run the service"
+}
+
+job "registry-garbage-collection" {
+  region = var.region
+
+  datacenters = [var.datacenter]
+
+  type = "batch"
+
+  periodic {
+    cron = "0 6 * * *"
+    prohibit_overlap = true
+  }
+
+  group "registry-garbage-collection" {
+    task "registry-garbage-collection" {
+      driver = "docker"
+
+      config {
+        image = "registry"
+
+        force_pull = true
+
+        network_mode = "host"
+
+        entrypoint = [
+          "/bin/registry",
+          "garbage-collect",
+          "--delete-untagged=true",
+          "/etc/docker/registry/config.yml",
+        ]
+
+        mount {
+          type   = "bind"
+          source = "secrets/"
+          target = "/etc/docker/registry/"
+        }
+
+        mount {
+          type = "volume"
+          target = "/registry/"
+          source = "registry"
+          readonly = false
+
+          volume_options {
+            no_copy = true
+          }
+        }
+      }
+
+      resources {
+        cpu = 1000
+        memory = 512
+        memory_max = 2048
+      }
+
+      template {
+        data = <<EOH
+---
+version: 0.1
+
+storage:
+  filesystem:
+    rootdirectory: /registry
+  cache:
+    blobdescriptor: inmemory
+EOH
+
+        destination = "secrets/config.yml"
+      }
+    }
+  }
+}

--- a/roles/registry/files/registry.nomad
+++ b/roles/registry/files/registry.nomad
@@ -1,0 +1,143 @@
+variable "region" {
+  type = string
+  description = "The region in which to run the service"
+}
+
+variable "datacenter" {
+  type = string
+  description = "The datacenter in which to run the service"
+}
+
+job "registry" {
+  region = var.region
+
+  datacenters = [var.datacenter]
+
+  type = "service"
+
+  group "registry" {
+    network {
+      port "http" {}
+    }
+
+    task "registry" {
+      driver = "docker"
+
+      config {
+        image = "registry"
+
+        force_pull = true
+
+        network_mode = "host"
+
+        mount {
+          type   = "bind"
+          source = "secrets/"
+          target = "/etc/docker/registry/"
+        }
+
+        mount {
+          type = "volume"
+          target = "/registry/"
+          source = "registry"
+          readonly = false
+
+          volume_options {
+            no_copy = true
+          }
+        }
+      }
+
+      resources {
+        cpu = 100
+        memory = 512
+        memory_max = 2048
+      }
+
+      template {
+        data = <<EOH
+---
+version: 0.1
+
+storage:
+  filesystem:
+    rootdirectory: /registry
+  cache:
+    blobdescriptor: inmemory
+
+http:
+  addr: 127.0.0.1:{{ env "NOMAD_PORT_http" }}
+  net: tcp
+  host: registry.${var.datacenter}.robojackets.net
+
+auth:
+  htpasswd:
+    realm: registry.${var.datacenter}.robojackets.net
+    path: /etc/docker/registry/htpasswd
+EOH
+
+        destination = "secrets/config.yml"
+      }
+
+      template {
+        data = <<EOH
+{{- key "registry/htpasswd" | trimSpace -}}
+EOH
+
+        destination = "secrets/htpasswd"
+      }
+
+      service {
+        name = "registry"
+
+        port = "http"
+
+        address = "127.0.0.1"
+
+        tags = [
+          "http"
+        ]
+
+        check {
+          success_before_passing = 3
+          failures_before_critical = 2
+
+          interval = "5s"
+
+          name = "HTTP"
+          path = "/"
+          port = "http"
+          protocol = "http"
+          timeout = "1s"
+          type = "http"
+        }
+
+        check_restart {
+          limit = 5
+          grace = "20s"
+        }
+
+        meta {
+          nginx-config = "client_max_body_size 0;location / {proxy_pass http://registry;proxy_set_header Host $http_host;proxy_set_header X-Real-IP $remote_addr;proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;proxy_set_header X-Forwarded-Proto $scheme;proxy_read_timeout 900;}"
+          firewall-rules = jsonencode(["aws", "local", "uptime-robot", "internet"])
+        }
+      }
+
+      restart {
+        attempts = 1
+        delay = "10s"
+        interval = "1m"
+        mode = "fail"
+      }
+    }
+
+    reschedule {
+      attempts  = 0
+      unlimited = false
+    }
+  }
+
+  update {
+    max_parallel = 0
+  }
+}

--- a/roles/registry/tasks/main.yml
+++ b/roles/registry/tasks/main.yml
@@ -1,0 +1,254 @@
+---
+#
+# Deploys a private Docker Registry
+# https://docs.docker.com/registry/
+#
+- name: Check if htpasswd has been loaded in Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/kv/registry/htpasswd
+    status_code:
+    - 200
+    - 404
+  register: registry_htpasswd
+
+- name: Configure registry credentials
+  when: registry_htpasswd.status == 404
+  block:
+
+  - name: Install httpd-tools
+    ansible.builtin.yum:
+      name:
+      - httpd-tools
+      state: present
+
+  - name: Generate registry password
+    ansible.builtin.set_fact:
+      registry_password: "{{ lookup('ansible.builtin.password', 'credentials/registry-password', chars=['ascii_letters', 'digits'], length=128) }}"
+      cacheable: yes
+
+  - name: Write config file so root can pull images
+    ansible.builtin.template:
+      src: config.json
+      dest: /root/.docker/config.json
+      owner: root
+      group: root
+      mode: '0400'
+
+  - name: Hash password with htpasswd
+    ansible.builtin.command:
+      argv:
+      - htpasswd
+      - -nbB
+      - -C
+      - 17
+      - robojacketsregistry
+      - "{{ ansible_facts['registry_password'] }}"
+    register: htpasswd_output
+
+  - name: Store htpasswd output in Consul
+    ansible.builtin.uri:
+      follow_redirects: none
+      force: true
+      return_content: true
+      unix_socket: /var/opt/nomad/run/consul.sock
+      use_netrc: false
+      use_proxy: false
+      validate_certs: false
+      body: "{{ htpasswd_output.stdout }}"
+      headers:
+        X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+      method: PUT
+      url: http://localhost/v1/kv/registry/htpasswd
+    changed_when: true
+
+- name: Generate job submission JSON
+  ansible.builtin.command:
+    argv:
+    - nomad
+    - job
+    - run
+    - -no-color
+    - -output
+    - -var
+    - region={{ region }}
+    - -var
+    - datacenter={{ datacenter }}
+    - "-"
+    stdin: "{{ lookup('ansible.builtin.file', './registry.nomad') }}"
+  register: nomad_job_json
+  changed_when: false
+
+- name: Submit job to Nomad
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    body: "{{ nomad_job_json.stdout }}"
+    body_format: json
+    method: POST
+    url: http://127.0.0.1:4646/v1/jobs
+  register: job_register_output
+
+- name: List allocations for evaluation
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: GET
+    url: http://127.0.0.1:4646/v1/evaluation/{{ job_register_output.json.EvalID }}/allocations
+  register: allocations_output
+
+- name: Wait for container to start
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: GET
+    url: http://127.0.0.1:4646/v1/allocation/{{ allocations_output.json[0].ID }}
+  register: allocation_output
+  until: allocation_output.json.TaskStates.registry.State == "running"
+  retries: 5
+  delay: 2
+  when: (allocations_output.json | length) > 0
+
+- name: Wait for health checks in Consul to be passing
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/health/checks/registry
+  register: service_status
+  until: service_status.json[0].Status == "passing"
+  retries: 5
+  delay: 2
+
+- name: Generate garbage collection job submission JSON
+  ansible.builtin.command:
+    argv:
+    - nomad
+    - job
+    - run
+    - -no-color
+    - -output
+    - -var
+    - region={{ region }}
+    - -var
+    - datacenter={{ datacenter }}
+    - "-"
+    stdin: "{{ lookup('ansible.builtin.file', './registry-garbage-collection.nomad') }}"
+  register: nomad_job_json
+  changed_when: false
+
+- name: Submit garbage collection job to Nomad
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    body: "{{ nomad_job_json.stdout }}"
+    body_format: json
+    method: POST
+    url: http://127.0.0.1:4646/v1/jobs
+
+- name: Get mount point for registry volume
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    unix_socket: /var/run/docker.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    method: GET
+    return_content: true
+    url: http://localhost/v1.43/volumes/registry
+  register: registry_volume
+
+- name: Check if registry has contents
+  ansible.builtin.stat:
+    path: "{{ registry_volume.json.Mountpoint }}/docker/registry/v2/repositories/"
+  register: registry_contents
+
+- name: Force launch garbage collection job if registry has contents
+  when: registry_contents.stat.exists
+  block:
+
+  - name: Force launch the job
+    ansible.builtin.uri:
+      follow_redirects: none
+      force: true
+      use_netrc: false
+      use_proxy: false
+      validate_certs: false
+      return_content: true
+      headers:
+        X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+      method: POST
+      url: http://127.0.0.1:4646/v1/job/registry-garbage-collection/periodic/force
+    register: force_launch_output
+
+  - name: List allocations for evaluation
+    ansible.builtin.uri:
+      follow_redirects: none
+      force: true
+      use_netrc: false
+      use_proxy: false
+      validate_certs: false
+      return_content: true
+      headers:
+        X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+      method: GET
+      url: http://127.0.0.1:4646/v1/evaluation/{{ force_launch_output.json.EvalID }}/allocations
+    register: evaluation_output
+
+  - name: Wait for allocation to complete
+    ansible.builtin.uri:
+      follow_redirects: none
+      force: true
+      use_netrc: false
+      use_proxy: false
+      validate_certs: false
+      return_content: true
+      headers:
+        X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+      method: GET
+      url: http://127.0.0.1:4646/v1/allocation/{{ evaluation_output.json[0].ID }}
+    register: allocation_output
+    until: allocation_output.json.ClientStatus == "complete"
+    retries: 5
+    delay: 2

--- a/roles/registry/templates/config.json
+++ b/roles/registry/templates/config.json
@@ -1,0 +1,7 @@
+{
+    "auths": {
+        "registry.{{ datacenter }}.robojackets.net": {
+            "auth": "{{ ('robojacketsregistry:' + ansible_facts['registry_password']) | b64encode }}"
+        }
+    }
+}

--- a/roles/tika/files/tika.nomad
+++ b/roles/tika/files/tika.nomad
@@ -1,0 +1,97 @@
+variable "region" {
+  type = string
+  description = "The region in which to run the service"
+}
+
+variable "datacenter" {
+  type = string
+  description = "The datacenter in which to run the service"
+}
+
+job "tika" {
+  region = var.region
+
+  datacenters = [var.datacenter]
+
+  type = "service"
+
+  group "tika" {
+    network {
+      port "http" {}
+    }
+
+    task "tika" {
+      driver = "docker"
+
+      config {
+        image = "apache/tika:latest-full"
+
+        force_pull = true
+
+        network_mode = "host"
+
+        args = [
+          "--host=127.0.0.1",
+          "--port=${NOMAD_PORT_http}"
+        ]
+      }
+
+      env {
+        JAVA_OPTS = "-Xms2048M -Xmx4096M -XX:MaxDirectMemorySize=256M"
+      }
+
+      resources {
+        cpu = 1000
+        memory = 2048
+        memory_max = 4096
+      }
+
+      service {
+        name = "tika"
+
+        port = "http"
+
+        address = "127.0.0.1"
+
+        tags = [
+          "http"
+        ]
+
+        check {
+          success_before_passing = 3
+          failures_before_critical = 2
+
+          interval = "5s"
+
+          name = "HTTP"
+          path = "/tika"
+          port = "http"
+          protocol = "http"
+          timeout = "1s"
+          type = "http"
+        }
+
+        check_restart {
+          limit = 5
+          grace = "20s"
+        }
+      }
+
+      restart {
+        attempts = 1
+        delay = "10s"
+        interval = "1m"
+        mode = "fail"
+      }
+    }
+
+    reschedule {
+      attempts  = 0
+      unlimited = false
+    }
+  }
+
+  update {
+    max_parallel = 0
+  }
+}

--- a/roles/tika/tasks/main.yml
+++ b/roles/tika/tasks/main.yml
@@ -1,0 +1,87 @@
+---
+#
+# Deploys Tika, used for text extraction and OCR from arbitrary file types
+# https://tika.apache.org/
+#
+- name: Generate job submission JSON
+  ansible.builtin.command:
+    argv:
+    - nomad
+    - job
+    - run
+    - -no-color
+    - -output
+    - -var
+    - region={{ region }}
+    - -var
+    - datacenter={{ datacenter }}
+    - "-"
+    stdin: "{{ lookup('ansible.builtin.file', './tika.nomad') }}"
+  register: nomad_job_json
+  changed_when: false
+
+- name: Submit job to Nomad
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    body: "{{ nomad_job_json.stdout }}"
+    body_format: json
+    method: POST
+    url: http://127.0.0.1:4646/v1/jobs
+  register: job_register_output
+
+- name: List allocations for evaluation
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: GET
+    url: http://127.0.0.1:4646/v1/evaluation/{{ job_register_output.json.EvalID }}/allocations
+  register: allocations_output
+
+- name: Wait for container to start
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: GET
+    url: http://127.0.0.1:4646/v1/allocation/{{ allocations_output.json[0].ID }}
+  register: allocation_output
+  until: allocation_output.json.TaskStates.tika.State == "running"
+  retries: 20
+  delay: 2
+  when: (allocations_output.json | length) > 0
+
+- name: Wait for health check in Consul to be passing
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/health/checks/tika
+  register: service_status
+  until: service_status.json[0].Status == "passing"
+  retries: 10
+  delay: 2

--- a/roles/vouch/tasks/main.yml
+++ b/roles/vouch/tasks/main.yml
@@ -98,7 +98,7 @@
       url: http://127.0.0.1:4646/v1/allocation/{{ allocations_output.json[0].ID }}
     register: allocation_output
     until: allocation_output.json.TaskStates.vouch.State == "running"
-    retries: 5
+    retries: 10
     delay: 2
     when: (allocations_output.json | length) > 0
 


### PR DESCRIPTION
- Add batch job for renewing ACME certificate, if issued
- Add housekeeping batch jobs
    - `docker system prune`
    - Unmounting `/nethome/`s for logged-out users
    - Garbage collection for self-hosted registry
- Add Meilisearch, MySQL, Redis, Docker Registry, Tika service jobs
- Updates to Nginx configuration
    - `/robots.txt` added to all servers to prevent indexing
    - Stub server configured to make Vouch outages more obvious
    - Using some caching trickery to allow web UI access based on IP address even if Vouch is unavailable