### PR TITLE
Control plane authentication improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,6 @@ Ansible playbook for shared infrastructure
 
 You do **not** need Nomad or Consul installed locally, but they may be helpful.
 
-### Notes on certificate issuance
-
-This playbook will attempt to issue an ACME certificate for the fully-qualified domain name specified in the inventory using the [http-01 challenge](https://letsencrypt.org/docs/challenge-types/). This means that the domain name must be **resolvable in public DNS** and the host must have **port 80 open to the Internet**. If the challenge fails, a self-signed certificate will be used.
-
-For OIT-managed hosts, DNS setup should be completed before system is handed off. Firewall changes must be submitted to the CSR responsible for the VLAN.
-
-The playbook will check if the http-01 challenge passes from the controller's perspective (i.e. your machine), but if you are running this against an OIT-managed system, that is not necessarily representative of what Let's Encrypt or another ACME issuer would see.
-
-The certificate will also have SANs for `*.{datacenter}.robojackets.net` and `*.robojackets.org`, using dns-01 challenges. You will be prompted for Hurricane Electric credentials when necessary.
-
 Set up an inventory file like so:
 
 ```yaml

--- a/roles/acme-issuance/README.md
+++ b/roles/acme-issuance/README.md
@@ -1,0 +1,9 @@
+# acme-issuance
+
+This role will attempt to issue an ACME certificate for the fully-qualified domain name specified in the inventory using the [http-01 challenge](https://letsencrypt.org/docs/challenge-types/). This means that the domain name must be **resolvable in public DNS** and the host must have **port 80 open to the Internet**. If the challenge fails, a self-signed certificate will be used.
+
+For OIT-managed hosts, DNS setup should be completed before system is handed off. Firewall changes must be submitted to the CSR responsible for the VLAN.
+
+The role will check if the http-01 challenge passes from the controller's perspective (i.e. your machine), but if you are running this against an OIT-managed system, that is not necessarily representative of what Let's Encrypt or another ACME issuer would see.
+
+The certificate will also have SANs for `*.{datacenter}.robojackets.net` and `*.robojackets.org`, using dns-01 challenges. You will be prompted for Hurricane Electric credentials when necessary.

--- a/roles/consul/tasks/main.yml
+++ b/roles/consul/tasks/main.yml
@@ -6,8 +6,8 @@
 - name: Add HashiCorp repository
   ansible.builtin.yum_repository:
     name: hashicorp
-    description: Hashicorp Test - $basearch
-    baseurl: https://rpm.releases.hashicorp.com/RHEL/$releasever/$basearch/test
+    description: HashiCorp Stable - $basearch
+    baseurl: https://rpm.releases.hashicorp.com/RHEL/$releasever/$basearch/stable
     enabled: true
     gpgcheck: true
     gpgkey: https://rpm.releases.hashicorp.com/gpg

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -269,7 +269,7 @@
 
 - name: Set permissions on assets volume
   ansible.builtin.file:
-    path: "{{ docker_volume.json.Mountpoint }}/"
+    path: "{{ assets_volume.json.Mountpoint }}/"
     state: directory
     mode: '0777'
 

--- a/roles/nginx/templates/03-consul.conf
+++ b/roles/nginx/templates/03-consul.conf
@@ -96,7 +96,7 @@ server {
 
     proxy_pass http://vouch;
 
-    proxy_set_header Host $http_host;
+    proxy_set_header Host $host;
     proxy_set_header Cookie $http_cookie;
 
     proxy_pass_request_headers off;

--- a/roles/nginx/templates/04-nomad.conf
+++ b/roles/nginx/templates/04-nomad.conf
@@ -147,12 +147,15 @@ server {
   auth_request /validate;
 
   location = /validate {
+    internal;
+
     proxy_pass http://vouch;
 
-    proxy_set_header Host $http_host;
+    proxy_set_header Host $host;
+    proxy_set_header Cookie $http_cookie;
 
+    proxy_pass_request_headers off;
     proxy_pass_request_body off;
-    proxy_set_header Content-Length "";
 
     proxy_cache_valid 200 48h;
     proxy_cache control_plane_auth;

--- a/roles/nginx/templates/04-nomad.conf
+++ b/roles/nginx/templates/04-nomad.conf
@@ -70,7 +70,20 @@ server {
 
   {# auth-methods always needs to be visible so nomad login works nicely #}
 
-  location /v1/acl/auth-methods {
+  location = /v1/acl/auth-methods {
+    proxy_pass http://nomad;
+    proxy_read_timeout 360s;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection 'upgrade';
+    proxy_buffering off;
+    proxy_set_header Origin "${scheme}://${proxy_host}";
+
+    allow all;
+  }
+
+  {# oidc always needs to be visible so nomad login works nicely #}
+
+  location /v1/acl/oidc/ {
     proxy_pass http://nomad;
     proxy_read_timeout 360s;
     proxy_set_header Upgrade $http_upgrade;

--- a/roles/nomad/README.md
+++ b/roles/nomad/README.md
@@ -1,0 +1,63 @@
+# nomad
+
+This role configures Nomad to require an ACL token to interact with the control plane. The bootstrap token is stored in Consul at `/nomad/token`.
+
+You may want to set up OIDC authentication following the [Single Sign-On docs](https://developer.hashicorp.com/nomad/tutorials/single-sign-on)). Specific instructions for Keycloak are below.
+
+## Using Keycloak
+
+Configure the client like so:
+- Enable "Client authentication"
+- Disable "Direct access grants"
+- The "Valid redirect URIs" must include `http://localhost:4649/oidc/callback` for CLI authentication and `https://nomad.{{ datacenter }}.robojackets.net/ui/settings/tokens` for web authentication (matching redirect URIs in config below)
+- Remove all default "Client scopes"
+- Add a mapper to set the Keycloak username in the `username` claim in the token
+- Add a mapper to set the client roles in the `roles` claim in the token
+- Create a client role called `management` and add administrative users to the role
+
+Create a file with the following contents, with your specific values substituted in curly braces:
+```json
+{
+  "OIDCDiscoveryURL": "https://{{ keycloak server }}/realms/{{ realm id }}",
+  "OIDCClientID": "{{ client id }}",
+  "OIDCClientSecret": "{{ client secret }}",
+  "BoundAudiences": ["{{ client id }}"],
+  "AllowedRedirectURIs": [
+    "http://localhost:4649/oidc/callback",
+    "https://nomad.{{ datacenter }}.robojackets.net/ui/settings/tokens"
+  ],
+  "ClaimMappings": {
+    "username": "username"
+  },
+  "ListClaimMappings": {
+    "roles": "roles"
+  }
+}
+```
+
+If you haven't already, specify your Nomad server address and existing token:
+```sh
+export NOMAD_ADDR=https://nomad.{{ datacenter }}.robojackets.net
+export NOMAD_TOKEN=00000000-0000-0000-0000-000000000000 # substitute the bootstrap token or another management token
+```
+
+Create the auth method with
+```sh
+nomad acl auth-method create -type=OIDC \
+    -name=Keycloak \
+    -default=true \
+    -max-token-ttl=1h \
+    -token-locality=global \
+    -config=@your-config-file.json \
+    -token-name-format="keycloak-${value.username}"
+```
+
+Create the binding rule with
+```sh
+nomad acl binding-rule create \
+    -auth-method=Keycloak \
+    -bind-type=management \
+    -selector='management in list.roles'
+```
+
+At this point you should be able to use `nomad login` in a terminal or the "Sign in with Keycloak" button in the web interface.

--- a/roles/vouch/README.md
+++ b/roles/vouch/README.md
@@ -1,0 +1,41 @@
+# vouch
+
+This role manages a [Vouch](https://github.com/vouch/vouch-proxy) service that is used to authenticate access to the Nomad and Consul UIs.
+
+A `/vouch/config` key must be added to Consul with JSON configuration; this will be parsed and loaded as environment variables for the Vouch server.
+
+Fully configuring Vouch is outside of the scope of this document, but at a minimum, the following keys need to be set:
+
+```json
+{
+  "VOUCH_DOMAINS": "{{ datacenter }}.robojackets.net",
+  "OAUTH_PROVIDER": "pick-a-provider",
+  "OAUTH_CLIENT_ID": "client-id-from-provider",
+  "OAUTH_CLIENT_SECRET": "client-secret-from-provider",
+  "OAUTH_CALLBACK_URL": "https://vouch.{{ datacenter }}.robojackets.net/auth",
+}
+```
+
+If using Keycloak, use the following configuration:
+
+```json
+{
+  "VOUCH_WHITELIST": "comma separated list of admin usernames",
+  "VOUCH_DOMAINS": "{{ datacenter }}.robojackets.net",
+  "OAUTH_PROVIDER": "oidc",
+  "OAUTH_CLIENT_ID": "vouch-{{ datacenter }}",
+  "OAUTH_CLIENT_SECRET": "client-secret-from-provider",
+  "OAUTH_CALLBACK_URL": "https://vouch.{{ datacenter }}.robojackets.net/auth",
+  "OAUTH_AUTH_URL": "https://{{ keycloak server }}/realms/{{ realm id }}/protocol/openid-connect/auth",
+  "OAUTH_TOKEN_URL": "https://{{ keycloak server }}/realms/{{ realm id }}/protocol/openid-connect/token",
+  "OAUTH_USER_INFO_URL": "https://{{ keycloak server }}/realms/{{ realm id }}/protocol/openid-connect/userinfo",
+  "OAUTH_SCOPES": "openid"
+}
+```
+
+When configuring the client within Keycloak:
+- Enable "Client authentication"
+- Disable "Direct access grants"
+- The "Valid redirect URIs" must match what you configure in Consul
+- Remove all default "Client scopes"
+- Add a mapper to set the Keycloak username in the `email` claim in the token

--- a/roles/vouch/files/vouch.nomad
+++ b/roles/vouch/files/vouch.nomad
@@ -33,7 +33,7 @@ job "vouch" {
 
       template {
         data = <<EOH
-{{- range $key, $value := (key "vouch" | parseJSON) -}}
+{{- range $key, $value := (key "vouch/config" | parseJSON) -}}
 {{- $key | trimSpace -}}={{- $value | toJSON }}
 {{ end -}}
 VOUCH_PORT={{ env "NOMAD_PORT_http" }}
@@ -81,7 +81,7 @@ EOH
         }
 
         meta {
-          nginx-config = "location / {proxy_pass http://vouch;proxy_set_header Host $http_host;} location /static/ {proxy_pass http://vouch;proxy_pass_request_headers off;proxy_pass_request_body off;proxy_cache vouch_assets;proxy_cache_valid 24h;add_header X-Cache-Status $upstream_cache_status;}"
+          nginx-config = "location / {proxy_pass http://vouch;proxy_set_header Host $host;} location /static/ {proxy_pass http://vouch;proxy_pass_request_headers off;proxy_pass_request_body off;proxy_cache vouch_assets;proxy_cache_valid 24h;add_header X-Cache-Status $upstream_cache_status;}"
           firewall-rules = jsonencode(["internet"])
         }
       }

--- a/roles/vouch/tasks/main.yml
+++ b/roles/vouch/tasks/main.yml
@@ -15,7 +15,7 @@
     headers:
       X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
     method: GET
-    url: http://localhost/v1/kv/vouch
+    url: http://localhost/v1/kv/vouch/config
     status_code:
     - 200
   register: vouch_config


### PR DESCRIPTION
- Moved ACME issuance notes from top-level README to role README
- Swapped back to HashiCorp stable releases now that Nomad 1.7 is out
- Fixed Vouch on http/3
- Add instructions for configuring Vouch
- Add instructions for configuring Nomad OIDC authentication