### PR TITLE
Set up Nomad workload identity for Consul

### DIFF
--- a/roles/nginx/files/nginx.nomad
+++ b/roles/nginx/files/nginx.nomad
@@ -139,14 +139,16 @@ upstream {{ .Name }} {
   server 127.0.0.1:{{ .Port }};{{ end -}}
   {{- end }}
 
-    keepalive 8;
+  keepalive 8;
 }
 
 {{ end -}}
 {{- end -}}
-{{ if not (service "vouch") }}
+{{- if not (service "vouch") -}}
 upstream vouch {
   server 127.0.0.1:{{ env "NOMAD_PORT_vouch_stub" }};
+
+  keepalive 8;
 }
 {{ end }}
 server {

--- a/roles/nomad/README.md
+++ b/roles/nomad/README.md
@@ -67,22 +67,7 @@ At this point you should be able to use `nomad login` in a terminal or the "Sign
 
 ## GitHub Actions
 
-Create a file with the following contents, with your specific values substituted in curly braces:
-```json
-{
-  "OIDCDiscoveryURL": "https://token.actions.githubusercontent.com",
-  "ExpirationLeeway": "1m",
-  "ClockSkewLeeway": "1m",
-  "BoundAudiences": ["https://nomad.{{ datacenter }}.robojackets.net"],
-  "ClaimMappings": {
-    "repository_id": "repository_id",
-    "repository_owner_id": "repository_owner_id",
-    "environment": "environment",
-    "actor": "actor",
-    "repository": "repository"
-  }
-}
-```
+An authentication method will be created automatically for GitHub Actions, however you will need to configure binding rules to allow access for specific repositories.
 
 If you haven't already, specify your Nomad server address and existing token:
 ```sh
@@ -90,20 +75,10 @@ export NOMAD_ADDR=https://nomad.{{ datacenter }}.robojackets.net
 export NOMAD_TOKEN=00000000-0000-0000-0000-000000000000 # substitute the bootstrap token or another management token
 ```
 
-Create the auth method with
-```sh
-nomad acl auth-method create -type=JWT \
-    -name=GitHub \
-    -max-token-ttl=1m \
-    -token-locality=global \
-    -config=@your-config-file.json \
-    -token-name-format="github-actions-deploy-${value.actor}-${value.repository}-${value.environment}"
-```
-
-Create the binding rule with
+Create a binding rule with
 ```sh
 nomad acl binding-rule create \
-    -auth-method=GitHub \
+    -auth-method=GitHubActions \
     -bind-type=management \
     -selector='value.repository_owner_id == 3523251 and value.repository_id == 92999743' \
     -description='Allow GitHub Actions from apiary'

--- a/roles/nomad/tasks/main.yml
+++ b/roles/nomad/tasks/main.yml
@@ -154,6 +154,58 @@
     status_code: [200]
   when: nomad_token_present.status == 404
 
+- name: Check if GitHub Actions auth method is configured in Nomad
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    return_content: true
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: GET
+    url: http://127.0.0.1:4646/v1/acl/auth-method/GitHubActions
+    status_code:
+    - 200
+    - 404
+  register: github_actions_auth_method
+
+- name: Create GitHub Actions auth method in Nomad
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    body:
+      Name: GitHubActions
+      Type: JWT
+      TokenLocality: global
+      TokenNameFormat: github-actions-${value.actor}-${value.repository}-${value.environment}
+      MaxTokenTTL: 15m
+      Default: false
+      Config:
+        OIDCDiscoveryURL: https://token.actions.githubusercontent.com
+        ExpirationLeeway: 1m
+        ClockSkewLeeway: 1m
+        BoundAudiences: ["https://nomad.{{ datacenter }}.robojackets.net"]
+        ClaimMappings:
+          repository_id: repository_id
+          repository_owner_id: repository_owner_id
+          environment: environment
+          actor: actor
+          repository: repository
+    body_format: json
+    headers:
+      X-Nomad-Token: "{{ ansible_facts['nomad_token'] }}"
+    method: POST
+    url: http://127.0.0.1:4646/v1/acl/auth-method
+    status_code:
+    - 200
+  when: github_actions_auth_method.status == 404
+
 - name: Check if Nomad auth method is configured within Consul
   ansible.builtin.uri:
     follow_redirects: none

--- a/roles/nomad/tasks/main.yml
+++ b/roles/nomad/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
 #
-# Install Nomad and bootstrap ACLs
+# Install Nomad, bootstrap Nomad ACL, configure Workload Identity within Consul ACL
 # https://developer.hashicorp.com/nomad/tutorials/access-control/access-control-bootstrap
+# https://developer.hashicorp.com/nomad/tutorials/integrate-consul/consul-acl
 #
 # Assumes Consul role already executed successfully
 #
@@ -152,3 +153,204 @@
     url: http://localhost/v1/kv/nomad/token
     status_code: [200]
   when: nomad_token_present.status == 404
+
+- name: Check if Nomad auth method is configured within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/acl/auth-method/nomad
+    status_code:
+    - 200
+    - 404
+  register: auth_method_present
+
+- name: Configure Nomad auth method within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    body:
+      Name: nomad
+      Type: jwt
+      Config:
+        JWKSURL: http://127.0.0.1:4646/.well-known/jwks.json
+        JWTSupportedAlgs: [RS256]
+        BoundIssuer: "https://nomad.{{ datacenter }}.robojackets.net"
+        BoundAudiences: ["https://consul.{{ datacenter }}.robojackets.net"]
+        ClaimMappings:
+          nomad_namespace: nomad_namespace
+          nomad_job_id: nomad_job_id
+          nomad_task: nomad_task
+          nomad_service: nomad_service
+    body_format: json
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: PUT
+    url: http://localhost/v1/acl/auth-method
+    status_code:
+    - 200
+    - 404
+  when: auth_method_present.status == 404
+
+- name: Check if Nomad binding rules are configured within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/acl/binding-rules?authmethod=nomad
+    status_code:
+    - 200
+  register: binding_rules
+
+- name: Create Nomad service binding rule within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    body:
+      Description: Binding rule for services registered from Nomad
+      AuthMethod: nomad
+      Selector: >-
+        "nomad_service" in value
+      BindType: service
+      BindName: ${value.nomad_service}
+    body_format: json
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: PUT
+    url: http://localhost/v1/acl/binding-rule
+  when: (binding_rules.json | length) == 0
+
+- name: Create Nomad task binding rule within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    body:
+      Description: Binding rule for Nomad tasks
+      AuthMethod: nomad
+      Selector: >-
+        "nomad_service" not in value
+      BindType: role
+      BindName: nomad-task
+    body_format: json
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: PUT
+    url: http://localhost/v1/acl/binding-rule
+  when: (binding_rules.json | length) == 0
+
+- name: Check if Nomad task policy is configured within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/acl/policy/name/nomad-task
+    status_code:
+    - 200
+    - 404
+  register: task_policy
+
+- name: Create Nomad task policy within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    body:
+      Name: nomad-task
+      Description: ACL policy used by Nomad tasks
+      Rules: |
+        key_prefix "" {
+          policy = "read"
+        }
+
+        service_prefix "" {
+          policy = "read"
+        }
+
+        node_prefix "" {
+          policy = "read"
+        }
+    body_format: json
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: PUT
+    url: http://localhost/v1/acl/policy
+  when: task_policy.status == 404
+
+- name: Check if Nomad task role is configured within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: GET
+    url: http://localhost/v1/acl/role/name/nomad-task
+    status_code:
+    - 200
+    - 404
+  register: task_role
+
+- name: Create Nomad task role within Consul
+  ansible.builtin.uri:
+    follow_redirects: none
+    force: true
+    return_content: true
+    unix_socket: /var/opt/nomad/run/consul.sock
+    use_netrc: false
+    use_proxy: false
+    validate_certs: false
+    body:
+      Name: nomad-task
+      Description: ACL role for Nomad tasks
+      Policies:
+      - Name: nomad-task
+    body_format: json
+    headers:
+      X-Consul-Token: "{{ ansible_facts['consul_token'] }}"
+    method: PUT
+    url: http://localhost/v1/acl/role
+  when: task_role.status == 404

--- a/roles/nomad/templates/nomad.hcl
+++ b/roles/nomad/templates/nomad.hcl
@@ -50,6 +50,18 @@ acl {
 consul {
   address = "unix:///var/opt/nomad/run/consul.sock"
   token = "{{ ansible_facts['consul_token'] }}"
+
+  service_auth_method = "nomad"
+  service_identity {
+    aud = ["https://consul.{{ datacenter }}.robojackets.net"]
+    ttl = "1h"
+  }
+
+  task_auth_method = "nomad"
+  task_identity {
+    aud = ["https://consul.{{ datacenter }}.robojackets.net"]
+    ttl = "1h"
+  }
 }
 
 region = "{{ region }}"


### PR DESCRIPTION
https://developer.hashicorp.com/nomad/tutorials/integrate-consul/consul-acl

This works almost exactly the same way as the globally shared Consul token in practice, with the exception that services must now be named exactly the same as the job. Most if not all jobs are already set up this way by convention.

Nomad may at some point release an option to have nodes register with JWTs as well instead of needing Consul tokens configured.